### PR TITLE
allow to compare date and time fields with None; issue #133

### DIFF
--- a/src/petl/test/test_transform.py
+++ b/src/petl/test/test_transform.py
@@ -3,6 +3,7 @@ Tests for the petl.transform module.
 
 """
 
+from datetime import datetime
 
 from collections import OrderedDict
 
@@ -717,6 +718,43 @@ def test_sort_empty():
     ieq(expect, actual)
 
 
+def test_sort_none():
+    
+    table = (('foo', 'bar'),
+            ('C', 2),
+            ('A', 9),
+            ('A', None),
+            ('F', 1),
+            ('D', 10))
+    
+    result = sort(table, 'bar')
+    expectation = (('foo', 'bar'),
+                   ('A', None),
+                   ('F', 1),
+                   ('C', 2),
+                   ('A', 9),
+                   ('D', 10))
+    ieq(expectation, result)
+    
+    dt = datetime.now().replace
+
+    table = (('foo', 'bar'),
+            ('C', dt(hour=5)),
+            ('A', dt(hour=1)),
+            ('A', None),
+            ('F', dt(hour=9)),
+            ('D', dt(hour=17)))
+    
+    result = sort(table, 'bar')
+    expectation = (('foo', 'bar'),
+                   ('A', None),
+                   ('A', dt(hour=1)),
+                   ('C', dt(hour=5)),
+                   ('F', dt(hour=9)),
+                   ('D', dt(hour=17)))
+    ieq(expectation, result)
+    
+    
 def test_melt_1():
     
     table = (('id', 'gender', 'age'),

--- a/src/petl/transform.py
+++ b/src/petl/transform.py
@@ -18,7 +18,7 @@ from petl.util import asindices, rowgetter, asdict,\
     values, shortlistmergesorted, heapqmergesorted, hybridrows, rowgroupby,\
     iterpeek
 from petl.io import Uncacheable
-from petl.util import RowContainer
+from petl.util import RowContainer, sortable_itemgetter
 
 
 def rename(table, *args):
@@ -1471,9 +1471,11 @@ class SortView(RowContainer):
         if key is not None:
             # convert field selection into field indices
             indices = asindices(flds, key)
-            # now use field indices to construct a _getkey function
-            # N.B., this will probably raise an exception on short rows
-            getkey = itemgetter(*indices)
+        else:
+            indices = range(len(flds))
+        # now use field indices to construct a _getkey function
+        # N.B., this will probably raise an exception on short rows
+        getkey = sortable_itemgetter(*indices)
         
         # initialise the first chunk
         rows = list(islice(it, 0, self.buffersize))
@@ -1931,7 +1933,7 @@ def iterrecast(source, key, variablefield, valuefield,
     
     source = sort(source, key=keyfields)
     it = islice(source, 1, None) # skip header row
-    getkey = itemgetter(*keyindices)
+    getkey = sortable_itemgetter(*keyindices)
     
     # process sorted data in newfields
     groups = groupby(it, key=getkey)

--- a/src/petl/util.py
+++ b/src/petl/util.py
@@ -2813,3 +2813,53 @@ def nthword(n, sep=None):
     return lambda s: s.split(sep)[n] 
 
 
+class SortableItem(object):
+    """
+    Wrapper to allow comparison with :const:`None` for objects
+    which support only comparison with same-type objects.
+
+    For example, the date and time objects from the standard library
+    cannot be compared with `None`.
+
+    .. versionadded:: 0.11
+
+    """
+    __slots__ = ['obj']
+    def __init__(self, obj):
+        self.obj = obj
+    def __eq__(self, other):
+        if isinstance(other, SortableItem):
+            return self.obj == other.obj
+        return self.obj == other
+    def __lt__(self, other):
+        if isinstance(other, SortableItem):
+            other = other.obj
+        if other is None:
+            return False
+        if self.obj is None:
+            return True
+        return self.obj < other
+    def __le__(self, other):
+        return self < other or self == other
+    def __gt__(self, other):
+        return not (self < other or self == other)
+    def __ge__(self, other):
+        return not (self < other)
+
+
+def sortable_itemgetter(*items):
+    """
+    Derivate of :func:`itertools.itemgetter` which can be safely
+    used as key for sort functions.
+
+    .. versionadded:: 0.11
+
+    """
+    ig = itemgetter(*items)
+    if len(items) == 1:
+        def g(obj):
+            return SortableItem(ig(obj))
+    else:
+        def g(obj):
+            return tuple([SortableItem(item) for item in ig(obj)])
+    return g


### PR DESCRIPTION
This should fix the comparison with None values.
The comparison operators will consider `None` as lower than anything.

In Python 2, this is the classic behaviour for standard types (except datetime objects).
