### PR TITLE
skip SortableItem wrapper for usual types

### DIFF
--- a/src/petl/util.py
+++ b/src/petl/util.py
@@ -22,7 +22,7 @@ import operator
 try:
     from collections import Counter, OrderedDict
 except ImportError:
-    from petl.compat import count, Counter, OrderedDict
+    from .compat import count, Counter, OrderedDict
 
 
 SINGLETONS = set([None, False, True])


### PR DESCRIPTION
I did not do benchmarks, but it should be a micro-optimization for known types.
