### PR TITLE
support for multiple source columns in multiple aggregations

### DIFF
--- a/src/petl/transform.py
+++ b/src/petl/transform.py
@@ -4071,6 +4071,16 @@ def itermultiaggregate(source, key, aggregation):
             if srcfld is None:
                 aggval = aggfun(rows)
                 outrow.append(aggval)
+            elif type(srcfld) is list:
+                indexes = []
+                for fld in srcfld:
+                    indexes.append(srcflds.index(fld))
+                def generator():
+                    for row in rows:
+                        yield [row[idx] for idx in indexes]
+                vals = generator()
+                aggval = aggfun(vals)
+                outrow.append(aggval)
             else:
                 idx = srcflds.index(srcfld)
                 # try using generator comprehension


### PR DESCRIPTION
> > > # aggregate multiple fields
> > > 
> > > ```
> > >     ... from collections import OrderedDict
> > >     >>> aggregation = OrderedDict()
> > >     >>> aggregation['count'] = len
> > >     >>> aggregation['minbar'] = 'bar', min
> > >     >>> aggregation['maxbar'] = 'bar', max
> > >     >>> aggregation['sumbar'] = 'bar', sum
> > >     >>> aggregation['listbar'] = 'bar' # default aggregation function is list
> > >     >>> aggregation['foosandbars'] = ['foo', 'bar'], list
> > >     >>> table5 = aggregate(table1, 'foo', aggregation)
> > >     >>> look(table5)
> > > ```
