### PR TITLE
Ensure compatibility with Python 2.6 by adding missing  itertools 2.7 

### DIFF
--- a/src/petl/base.py
+++ b/src/petl/base.py
@@ -11,9 +11,13 @@ except ImportError:
 
 
 from itertools import islice, imap, izip, izip_longest, chain, cycle, product,\
-    permutations, combinations, compress, takewhile, dropwhile, ifilter, ifilterfalse, \
-    starmap, groupby, tee, combinations_with_replacement
+    permutations, combinations, takewhile, dropwhile, ifilter, ifilterfalse, \
+    starmap, groupby, tee
 
+try: 
+    from itertools import compress, combinations_with_replacement
+except ImportError:
+    from .compat import compress, combinations_with_replacement
 
 class IterContainer(object):
     

--- a/src/petl/compat.py
+++ b/src/petl/compat.py
@@ -510,3 +510,26 @@ class Counter(dict):
             if newcount > 0:
                 result[elem] = newcount
         return result
+####################################################################
+#  itertools functions  new in Python 2.7 - Quick Fix:
+####################################################################
+def compress(data, selectors):
+    # compress('ABCDEF', [1,0,1,0,1,1]) --> A C E F
+    return (d for d, s in izip(data, selectors) if s)
+
+def combinations_with_replacement(iterable, r):
+    # combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC
+    pool = tuple(iterable)
+    n = len(pool)
+    if not n and r:
+        return
+    indices = [0] * r
+    yield tuple(pool[i] for i in indices)
+    while True:
+        for i in reversed(range(r)):
+            if indices[i] != n - 1:
+                break
+        else:
+            return
+        indices[i:] = [indices[i] + 1] * (r - i)
+        yield tuple(pool[i] for i in indices)


### PR DESCRIPTION
methods.  With this fix can now import petl under python 2.6.8 on Linux

I found it necessary to add this fix to be able to import petl in my Python 2.6.8 virtualenv on my Linux virtualhost at A2 Hosting  (which is typical of the large hosting companies in the US that offer basic Python support)  

I can't say I've fully tested this on more than Linux and OS X, but I feel it's pretty low risk due to the strategy of using

except ImportError: 
