### PR TITLE
added missing petl.io to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Alistair Miles',
     author_email='alimanfoo@googlemail.com',
     package_dir={'': 'src'},
-    packages=['petl', 'petl.transform'],
+    packages=['petl', 'petl.transform', 'petl.io'],
     scripts=['bin/petl'],
     url='https://github.com/alimanfoo/petl',
     license='MIT License',


### PR DESCRIPTION
After updating to the new release petl failed with "No module named petl.io". I guess this should fix it... maybe you should re-release... Thx for the great package...
