### PR TITLE
Allow universal newlines in fromcsv

### DIFF
--- a/src/petl/io/csv.py
+++ b/src/petl/io/csv.py
@@ -67,7 +67,7 @@ class CSVView(RowContainer):
         self.kwargs = kwargs
 
     def __iter__(self):
-        with self.source.open_('rb') as f:
+        with self.source.open_('rbU') as f:
             reader = csv.reader(f, dialect=self.dialect, **self.kwargs)
             for row in reader:
                 yield tuple(row)


### PR DESCRIPTION
Simple change to allow csv files to be pulled in regardless of line endings. Not sure whether this could possibly have any unpleasant consequences, and also not sure if other parts of petl might need changing if this is going to work universally, but solved my immediate issue.
