### PR TITLE
Allow FileSource to accept a callable

### DIFF
--- a/petl/io/sources.py
+++ b/petl/io/sources.py
@@ -24,6 +24,10 @@ debug = logger.debug
 
 
 class FileSource(object):
+    """
+    Wraps a file-like source. Can be initialized with a file path string, or any
+    callable that returns a context-managed file-like object.
+    """
 
     def __init__(self, path_or_opener, **kwargs):
         self.path_or_opener = path_or_opener

--- a/petl/io/sources.py
+++ b/petl/io/sources.py
@@ -25,12 +25,17 @@ debug = logger.debug
 
 class FileSource(object):
 
-    def __init__(self, filename, **kwargs):
-        self.filename = filename
+    def __init__(self, path_or_opener, **kwargs):
+        self.path_or_opener = path_or_opener
         self.kwargs = kwargs
 
     def open(self, mode='r'):
-        return io.open(self.filename, mode, **self.kwargs)
+        if callable(self.path_or_opener):
+            opener = self.path_or_opener()
+            if not hasattr(opener, '__exit__'):
+                raise ArgumentError('File opener must be a context manager')
+            return opener
+        return io.open(self.path_or_opener, mode, **self.kwargs)
 
 
 class GzipSource(object):


### PR DESCRIPTION
This change allows a `FileSource` to be initialized with any callable that returns a context-managed file-like object. This should be non-breaking, as passing in a string will still call `io.open` as petl currently does. Resolves #409.