### PR TITLE
Fixed helpers.py for Python 3.7 (PEP 479)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
   - master
 language: python
 python:
+  - "3.7"
   - "3.6"
   - "3.5"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
   - master
 language: python
 python:
-  - "3.7"
+  - "3.7-dev"
   - "3.6"
   - "3.5"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,16 @@ branches:
   only:
   - master
 language: python
-python:
-  - "3.7-dev"
-  - "3.6"
-  - "3.5"
-  - "3.4"
-  - "2.7"
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: false
+
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get build-dep -y python-h5py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,12 @@ environment:
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6"
 
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7"
+
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 

--- a/petl/test/helpers.py
+++ b/petl/test/helpers.py
@@ -8,14 +8,11 @@ from nose.tools import eq_, assert_almost_equal
 def ieq(expect, actual, cast=None):
     ie = iter(expect)
     ia = iter(actual)
-    try:
-        for e, a in izip_longest(ie, ia, fillvalue=None):
-            if cast:
-                a = cast(a)
-            eq_(e, a)
-    except:
-        return
- 
+    for e, a in izip_longest(ie, ia, fillvalue=None):
+        if cast:
+            a = cast(a)
+        eq_(e, a)
+        
     
 def test_iassertequal():
     x = ['a', 'b']

--- a/petl/test/helpers.py
+++ b/petl/test/helpers.py
@@ -8,11 +8,14 @@ from nose.tools import eq_, assert_almost_equal
 def ieq(expect, actual, cast=None):
     ie = iter(expect)
     ia = iter(actual)
-    for e, a in izip_longest(ie, ia, fillvalue=None):
-        if cast:
-            a = cast(a)
-        eq_(e, a)
-        
+    try:
+        for e, a in izip_longest(ie, ia, fillvalue=None):
+            if cast:
+                a = cast(a)
+            eq_(e, a)
+    except:
+        return
+ 
     
 def test_iassertequal():
     x = ['a', 'b']

--- a/petl/transform/dedup.py
+++ b/petl/transform/dedup.py
@@ -202,8 +202,12 @@ def iterunique(source, key):
     # N.B., this may raise an exception on short rows, depending on
     # the field selection
     getkey = operator.itemgetter(*indices)
-    
-    prev = next(it)
+
+    try:
+        prev = next(it)
+    except StopIteration:
+        return
+
     prev_key = getkey(prev)
     prev_comp_ne = True
     


### PR DESCRIPTION
Modification to fix nosetest helpers.py failing due to changes in Python 3.7 (PEP 479)

nosetests -v and tox -e py27,py36,py37 all passed after modifications.

No new unit tests
No new functions

