### PR TITLE
Make fromxlsx() compatible with openpyxl 2.6+

### DIFF
--- a/ci_requirements.txt
+++ b/ci_requirements.txt
@@ -5,7 +5,7 @@ numexpr==2.6.6
 tables==3.4.4
 intervaltree==2.1.0
 lxml==4.2.3
-openpyxl==2.5.4
+openpyxl==2.6.2
 pandas==0.22.0
 #psycopg2==2.7.5
 #PyMySQL==0.9.2

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,9 @@ Changes
 Version X.X
 -----------
 
-Documentation improvements by :user:`gamesbook` (:issue:`458`).
+* Documentation improvements by :user:`gamesbook` (:issue:`458`).
+* Updated :func:`petl.io.xlsx.fromxlsx` for compatibility with
+  openpyxl 2.6+.
 
 Version 1.2.0
 -------------

--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -62,9 +62,7 @@ class XLSXView(Table):
             ws_max_row = ws.max_row or 0
             ws_max_column = ws.max_column or 0
             rows = ws.iter_rows(min_row=self.row_offset+1,
-                                max_row=ws_max_row+self.row_offset,
-                                min_col=self.column_offset+1,
-                                max_col=ws_max_column+self.column_offset)
+                                min_col=self.column_offset+1)
 
         for row in rows:
             yield tuple(cell.value for cell in row)

--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -59,8 +59,6 @@ class XLSXView(Table):
         if self.range_string is not None:
             rows = ws[self.range_string]
         else:
-            ws_max_row = ws.max_row or 0
-            ws_max_column = ws.max_column or 0
             rows = ws.iter_rows(min_row=self.row_offset+1,
                                 min_col=self.column_offset+1)
 

--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -59,8 +59,12 @@ class XLSXView(Table):
         if self.range_string is not None:
             rows = ws[self.range_string]
         else:
-            rows = ws.iter_rows(row_offset=self.row_offset,
-                                column_offset=self.column_offset)
+            ws_max_row = ws.max_row or 0
+            ws_max_column = ws.max_column or 0
+            rows = ws.iter_rows(min_row=self.row_offset+1,
+                                max_row=ws_max_row+self.row_offset,
+                                min_col=self.column_offset+1,
+                                max_col=ws_max_column+self.column_offset)
 
         for row in rows:
             yield tuple(cell.value for cell in row)

--- a/petl/test/io/test_xlsx.py
+++ b/petl/test/io/test_xlsx.py
@@ -39,10 +39,10 @@ else:
         )
         tbl = fromxlsx(filename, 'Sheet1', row_offset=1, column_offset=1)
         print(tbl.lookall())
-        expect = ((1, None),
-                  (2, None),
-                  (2, None),
-                  (datetime(2012, 1, 1, 0, 0), None))
+        expect = ((1,),
+                  (2,),
+                  (2,),
+                  (datetime(2012, 1, 1, 0, 0),))
         ieq(expect, tbl)
         ieq(expect, tbl)
 

--- a/petl/test/io/test_xlsx.py
+++ b/petl/test/io/test_xlsx.py
@@ -33,6 +33,19 @@ else:
         ieq(expect, tbl)
         ieq(expect, tbl)
 
+    def test_fromxlsx_offset():
+        filename = pkg_resources.resource_filename(
+            'petl', 'test/resources/test.xlsx'
+        )
+        tbl = fromxlsx(filename, 'Sheet1', row_offset=1, column_offset=1)
+        print(tbl.lookall())
+        expect = ((1, None),
+                  (2, None),
+                  (2, None),
+                  (datetime(2012, 1, 1, 0, 0), None))
+        ieq(expect, tbl)
+        ieq(expect, tbl)
+
     def test_fromxlsx_nosheet():
         filename = pkg_resources.resource_filename(
             'petl', 'test/resources/test.xlsx'


### PR DESCRIPTION
openpyxl 2.6.0 removed the row_offset/column_offset arguments to worksheet.iter_rows(); the min/max_row/column arguments must be used instead.

This fix maintains compatibility with a probable bug in petl: When the column_offset argument is nonzero, the number of columns returned is the same as otherwise, and the table is padded with None values on the right. This does not happen with row_offset; the resulting table does not have any entirely blank rows at the end.

<!--
Checklist for for pull requests including new code and/or changes to existing code...
-->

* [X] Includes unit tests
* [] New functions have docstrings with examples that can be run with doctest
* [] New functions are included in API docs
* [X] Docstrings include notes for any changes to API or behaviour
* [] Travis CI passes (unit tests run under Linux)
* [] AppVeyor CI passes (unit tests run under Windows)
* [] Unit test coverage has not decreased (see Coveralls)
* [X] All changes documented in docs/changes.rst
