### PR TITLE
add helpers for xz, lz4 and zstandard codec and for s3 and smb remote servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@ MANIFEST
 dist
 .ipynb_checkpoints/
 .idea
+.vscode
 .tox/
 example*.*
 .coverage
+.eggs
 tmp*
 env/
 spike*

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,29 @@
 Changes
 =======
 
+Version 1.5.0
+-------------
+
+* Added functions :func:`petl.io.sources.register_reader` and
+  :func:`petl.io.sources.register_writer` for registering custom source helpers for
+  hanlding I/O from remote protocols.
+  By :user:`juarezr`, :issue:`491`.
+
+* Added function :func:`petl.io.sources.register_codec` for registering custom
+  helpers for compressing and decompressing files with other algorithms.
+  By :user:`juarezr`, :issue:`491`.
+
+* Added classes :class:`petl.io.codec.xz.XZCodec`, :class:`petl.io.codec.xz.LZ4Codec`
+  and :class:`petl.io.codec.zstd.ZstandardCodec` for compressing files with `XZ` and
+  the "state of art"  `LZ4` and `Zstandard` algorithms.
+  By :user:`juarezr`, :issue:`491`.
+
+* Added classes :class:`petl.io.source.s3.S3Source` and
+  :class:`petl.io.source.smb.SMBSource` reading and writing files to remote
+  servers using int url the protocols `s3://` and `smb://`.
+  By :user:`juarezr`, :issue:`491`.
+
+
 Version 1.4.0
 -------------
 

--- a/docs/io.rst
+++ b/docs/io.rst
@@ -20,6 +20,8 @@ string it is interpreted as follows:
 * string ending with `.bz2` - read from file via bz2 decompression
 * any other string - read directly from file
 
+.. _io_extract_codec:
+
 Some helper classes are also available for reading from other types of
 file-like sources, e.g., reading data from a Zip file, a string or a
 subprocess, see the section on :ref:`io_helpers` below for more
@@ -46,6 +48,8 @@ follows:
 * string ending with `.gz` or `.bgz` - write to file via gzip decompression
 * string ending with `.bz2` - write to file via bz2 decompression
 * any other string - write directly to file
+
+.. _io_load_codec:
 
 Some helper classes are also available for writing to other types of
 file-like sources, e.g., writing to a Zip file or string buffer, see
@@ -285,8 +289,8 @@ Text indexes (Whoosh)
 .. autofunction:: petl.io.whoosh.totextindex
 .. autofunction:: petl.io.whoosh.appendtextindex
 
-.. module:: petl.io.sources
-.. _io_helpers:
+.. module:: petl.io.avro
+.. _io_avro:
 
 Avro files (fastavro)
 ----------------------------
@@ -331,8 +335,8 @@ Avro files (fastavro)
    :start-after: begin_complex_schema
    :end-before: end_complex_schema
 
-.. module:: petl.io.avro
-.. _io_avro:
+.. module:: petl.io.sources
+.. _io_helpers:
 
 I/O helper classes
 ------------------
@@ -364,3 +368,53 @@ for full details.
 .. autoclass:: petl.io.sources.URLSource
 .. autoclass:: petl.io.sources.MemorySource
 .. autoclass:: petl.io.sources.PopenSource
+
+.. _io_remotes:
+
+Remote I/O helper classes
+-------------------------
+
+The following classes are helpers for reading (``from...()``) and writing
+(``to...()``) functions transparently as a file-like source.
+
+There are no need to instantiate them. They are used in the mecanism described
+in :ref:`Extract <io_extract>` and :ref:`Load <io_load>`.
+
+It's possible to read and write just by prefixing the protocol (e.g: `s3://`)
+in the source path of the file.
+
+.. autoclass:: petl.io.source.s3.S3Source
+.. autoclass:: petl.io.source.smb.SMBSource
+
+.. _io_codecs:
+
+Compression I/O helper classes
+------------------------------
+
+The following classes are helpers for decompressing (``from...()``) and 
+compressing (``to...()``) in functions transparently as a file-like source.
+
+There are no need to instantiate them. They are used in the mecanism described
+in :ref:`Extract <io_extract_codec>` and :ref:`Load <io_load_codec>`.
+
+It's possible to compress and decompress just by specifying the file extension
+(e.g: `.csv.xz`) in end of the source filename.
+
+.. autoclass:: petl.io.codec.xz.XZCodec
+.. autoclass:: petl.io.codec.zstd.ZstandardCodec
+.. autoclass:: petl.io.codec.lz4.LZ4Codec
+
+.. _io_custom_helpers:
+
+Custom I/O helper classes
+------------------------------
+
+For creating custom helpers for :ref:`remote I/O <io_remotes>` or
+:ref:`compression <io_codecs>` use the following functions:
+
+.. autofunction:: petl.io.sources.register_reader
+.. autofunction:: petl.io.sources.register_writer
+.. autofunction:: petl.io.sources.register_codec
+
+See the source code of the classes in :mod:`petl.io.sources` module for
+more details.

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -14,3 +14,5 @@ Whoosh==2.7.4
 xlrd==1.2.0
 xlwt==1.3.0
 fastavro>=0.23.4
+lz4
+zstandard

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -16,3 +16,5 @@ xlwt==1.3.0
 fastavro>=0.23.4
 lz4
 zstandard
+smbprotocol>=1.0.1
+s3fs>=0.2.2

--- a/petl/io/__init__.py
+++ b/petl/io/__init__.py
@@ -37,3 +37,5 @@ from petl.io.whoosh import fromtextindex, searchtextindex, \
 from petl.io.bcolz import frombcolz, tobcolz, appendbcolz
 
 from petl.io.avro import fromavro, toavro, appendavro
+
+from petl.io.sources import register_codec, register_reader, register_writer

--- a/petl/io/avro.py
+++ b/petl/io/avro.py
@@ -228,7 +228,7 @@ def appendavro(table, target, schema=None, sample=9, **avro_args):
     .. versionadded:: 1.4.0
 
     """
-    target2 = write_source_from_arg(target)
+    target2 = write_source_from_arg(target, mode='ab')
     _write_toavro(table,
                   target=target2,
                   mode='a+b',

--- a/petl/io/codec/__init__.py
+++ b/petl/io/codec/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, print_function, division
+
+from petl.io.codec.zstd import ZstandardCodec
+
+from petl.io.codec.lz4 import LZ4Codec
+
+from petl.io.codec.xz import XZCodec

--- a/petl/io/codec/lz4.py
+++ b/petl/io/codec/lz4.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+
+from contextlib import contextmanager
+
+from petl.io.sources import register_codec
+
+
+class LZ4Codec(object):
+    '''
+    Allows compressing and decompressing .lz4 files
+
+    `LZ4`_ is lossless compression algorithm, providing compression
+    speed greather than 500 MB/s per core (>0.15 Bytes/cycle). It features an
+    extremely fast decoder, with speed in multiple GB/s per core (~1Byte/cycle)
+
+    .. note::
+
+        For working this codec require `python-lz4`_ to be installed, e.g.::
+
+            $ pip install lz4
+
+    .. versionadded:: 1.5.0
+
+    .. _python-lz4: https://github.com/python-lz4/python-lz4
+    .. _LZ4: http://www.lz4.org
+    '''
+
+    def __init__(self, filename, **kwargs):
+        self.filename = filename
+        self.kwargs = kwargs
+
+    def open_file(self, mode='rb'):
+        import lz4.frame
+        source = lz4.frame.open(self.filename, mode=mode, **self.kwargs)
+        return source
+
+    @contextmanager
+    def open(self, mode='r'):
+        mode2 = mode[:1] + r'b' # python2
+        source = self.open_file(mode=mode2)
+        try:
+            yield source
+        finally:
+            source.close()
+
+
+register_codec('.lz4', LZ4Codec)
+
+# end #

--- a/petl/io/codec/xz.py
+++ b/petl/io/codec/xz.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+
+from contextlib import contextmanager
+
+from petl.io.sources import register_codec
+
+class XZCodec(object):
+    '''
+    Allows compressing and decompressing .xz files compressed with `lzma`_.
+
+    .. versionadded:: 1.5.0
+
+    .. _lzma: https://docs.python.org/3/library/lzma.html
+    '''
+
+    def __init__(self, filename, **kwargs):
+        self.filename = filename
+        self.kwargs = kwargs
+
+    def open_file(self, mode='rb'):
+        import lzma
+        source = lzma.open(self.filename, mode=mode, **self.kwargs)
+        return source
+
+    @contextmanager
+    def open(self, mode='r'):
+        mode2 = mode[:1] + r'b' # python2
+        source = self.open_file(mode=mode2)
+        try:
+            yield source
+        finally:
+            source.close()
+
+
+register_codec('.xz', XZCodec)
+
+# end #

--- a/petl/io/codec/zstd.py
+++ b/petl/io/codec/zstd.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+
+import io
+from contextlib import contextmanager
+
+from petl.io.sources import register_codec
+
+
+class ZstandardCodec(object):
+    '''
+    Allows compressing and decompressing .zstd files
+
+    `Zstandard`_ is a real-time compression algorithm, providing 
+    high compression ratios. It offers a very wide range of compression / speed
+    trade-off, while being backed by a very fast decoder.
+
+    .. note::
+
+        For working this codec require `zstd`_ to be installed, e.g.::
+
+            $ pip install zstandard
+
+    .. versionadded:: 1.5.0
+
+    .. _zstd: https://github.com/indygreg/python-zstandard
+    .. _Zstandard: http://www.zstd.net
+    '''
+
+    def __init__(self, filename, **kwargs):
+        self.filename = filename
+        self.kwargs = kwargs
+
+    def open_file(self, mode='rb'):
+        import zstandard as zstd
+        if mode.startswith('r'):
+            cctx = zstd.ZstdDecompressor(**self.kwargs)
+            compressed = io.open(self.filename, mode)
+            source = cctx.stream_reader(compressed)
+        else:
+            cctx = zstd.ZstdCompressor(**self.kwargs)
+            uncompressed = io.open(self.filename, mode)
+            source = cctx.stream_writer(uncompressed)
+        return source
+
+    @contextmanager
+    def open(self, mode='r'):
+        mode2 = mode[:1] + r'b'  # python2
+        source = self.open_file(mode=mode2)
+        try:
+            yield source
+        finally:
+            source.close()
+
+
+register_codec('.zst', ZstandardCodec)
+
+# end #

--- a/petl/io/csv.py
+++ b/petl/io/csv.py
@@ -125,7 +125,7 @@ def appendcsv(table, source=None, encoding=None, errors='strict',
 
     """
 
-    source = write_source_from_arg(source)
+    source = write_source_from_arg(source, mode='ab')
     csvargs.setdefault('dialect', 'excel')
     appendcsv_impl(table, source=source, encoding=encoding, errors=errors,
                    write_header=write_header, **csvargs)

--- a/petl/io/pickle.py
+++ b/petl/io/pickle.py
@@ -116,7 +116,7 @@ Table.appendpickle = appendpickle
 
 
 def _writepickle(table, source, mode, protocol, write_header):
-    source = write_source_from_arg(source)
+    source = write_source_from_arg(source, mode)
     with source.open(mode) as f:
         it = iter(table)
         hdr = next(it)

--- a/petl/io/source/__init__.py
+++ b/petl/io/source/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import, print_function, division
+
+from petl.io.source.s3 import S3Source
+
+from petl.io.source.smb import SMBSource

--- a/petl/io/source/s3.py
+++ b/petl/io/source/s3.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 
+import io
 from petl.io.sources import register_reader, register_writer
 from contextlib import contextmanager
 
@@ -8,12 +9,14 @@ from contextlib import contextmanager
 class S3Source(object):
     '''Downloads or uploads to AWS S3 filesystem. E.g.::
 
-        >>> import petl as etl
-        >>> url = b's3://mybucket/prefix/to/myfilename.csv'
-        >>> data = b'foo,bar\\na,1\\nb,2\\nc,2\\n'
-        >>> etl.tocsv(url, data)
-        >>> tbl = etl.fromcsv(source)
-        >>> tbl
+        >>> def example_s3():
+        ...     import petl as etl
+        ...     url = 's3://mybucket/prefix/to/myfilename.csv'
+        ...     data = b'foo,bar\\na,1\\nb,2\\nc,2\\n'
+        ...     etl.tocsv(data, url)
+        ...     tbl = etl.fromcsv(url)
+        ...     
+        >>> example_s3() # doctest: +SKIP
         +-----+-----+
         | foo | bar |
         +=====+=====+

--- a/petl/io/source/s3.py
+++ b/petl/io/source/s3.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+
+from petl.io.sources import register_reader, register_writer
+from contextlib import contextmanager
+
+
+class S3Source(object):
+    '''Downloads or uploads to AWS S3 filesystem. E.g.::
+
+        >>> import petl as etl
+        >>> url = b's3://mybucket/prefix/to/myfilename.csv'
+        >>> data = b'foo,bar\\na,1\\nb,2\\nc,2\\n'
+        >>> etl.tocsv(url, data)
+        >>> tbl = etl.fromcsv(source)
+        >>> tbl
+        +-----+-----+
+        | foo | bar |
+        +=====+=====+
+        | 'a' | '1' |
+        +-----+-----+
+        | 'b' | '2' |
+        +-----+-----+
+        | 'c' | '2' |
+        +-----+-----+
+
+    .. note::
+
+        For working this source require `s3fs`_ to be installed, e.g.::
+
+            $ pip install s3fs
+
+    It is strongly recommended that you open files in binary mode.
+
+    For authentication check `credentials`_.
+
+    .. versionadded:: 1.5.0
+
+    .. _s3fs: https://github.com/dask/s3fs/
+    .. _credentials: https://s3fs.readthedocs.io/en/latest/#credentials
+    '''
+
+    def __init__(self, url, **kwargs):
+        self.url = url
+        self.kwargs = kwargs
+
+    def open_file(self, mode='rb'):
+        import s3fs
+        fs = s3fs.S3FileSystem()
+        source = fs.open(self.url, mode=mode, **self.kwargs)
+        return source
+
+    @contextmanager
+    def open(self, mode='rb'):
+        mode2 = mode[:1] + r'b' # python2
+        source = self.open_file(mode=mode2)
+        try:
+            yield source
+        finally:
+            source.close()
+
+
+register_reader('s3', S3Source)
+register_writer('s3', S3Source)

--- a/petl/io/source/smb.py
+++ b/petl/io/source/smb.py
@@ -11,12 +11,14 @@ from petl.io.sources import register_reader, register_writer
 class SMBSource(object):
     '''Downloads or uploads to Windows and Samba network drives. E.g.::
 
-        >>> import petl as etl
-        >>> url = b'smb://workgroup;user:password@server:port/share/folder/file.csv'
-        >>> data = b'foo,bar\\na,1\\nb,2\\nc,2\\n'
-        >>> etl.tocsv(url, data)
-        >>> tbl = etl.fromcsv(source)
-        >>> tbl
+        >>> def example_smb():
+        ...     import petl as etl
+        ...     url = 'smb://user:password@server/share/folder/file.csv'
+        ...     data = b'foo,bar\\na,1\\nb,2\\nc,2\\n'
+        ...     etl.tocsv(data, url)
+        ...     tbl = etl.fromcsv(url)
+        ... 
+        >>> example_smb() # doctest: +SKIP
         +-----+-----+
         | foo | bar |
         +=====+=====+
@@ -100,14 +102,16 @@ def _parse_smb_url(url):
         raise ValueError(e + url)
 
     unc_path = parsed.path.replace("/", "\\")
-    server_path = "\\{}{}".format(parsed.hostname, unc_path)
+    server_path = "\\\\{}{}".format(parsed.hostname, unc_path)
+
     if not parsed.username:
         domain, username = None
     elif ';' in parsed.username:
         domain, username = parsed.username.split(';')
     else:
         domain, username = None, parsed.username
-    return domain, parsed.hostname, parsed.port or 445, username, parsed.password, server_path
+    port = 555 if not parsed.port else int(parsed.port)
+    return domain, parsed.hostname, port, username, parsed.password, server_path
 
 # endregion
 

--- a/petl/io/source/smb.py
+++ b/petl/io/source/smb.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+
+import sys
+from contextlib import contextmanager
+
+from petl.compat import PY3
+from petl.io.sources import register_reader, register_writer
+
+
+class SMBSource(object):
+    '''Downloads or uploads to Windows and Samba network drives. E.g.::
+
+        >>> import petl as etl
+        >>> url = b'smb://workgroup;user:password@server:port/share/folder/file.csv'
+        >>> data = b'foo,bar\\na,1\\nb,2\\nc,2\\n'
+        >>> etl.tocsv(url, data)
+        >>> tbl = etl.fromcsv(source)
+        >>> tbl
+        +-----+-----+
+        | foo | bar |
+        +=====+=====+
+        | 'a' | '1' |
+        +-----+-----+
+        | 'b' | '2' |
+        +-----+-----+
+        | 'c' | '2' |
+        +-----+-----+
+
+    The argument `url` (str) must have a URI with format:
+    `smb://workgroup;user:password@server:port/share/folder/file.csv`.
+
+    Note that you need to pass in a valid hostname or IP address for the host 
+    component of the URL. Do not use the Windows/NetBIOS machine name for the
+    host component.
+
+    The first component of the path in the URL points to the name of the shared
+    folder. Subsequent path components will point to the directory/folder/file.
+
+    .. note::
+
+        For working this source require `smbprotocol`_ to be installed, e.g.::
+
+            $ pip install smbprotocol[kerberos]
+
+    .. versionadded:: 1.5.0
+
+    .. _smbprotocol: https://github.com/jborean93/smbprotocol#requirements
+    '''
+
+    def __init__(self, url, **kwargs):
+        self.url = url
+        self.kwargs = kwargs
+
+    @contextmanager
+    def open(self, mode='rb'):
+        mode2 = mode[:1] + r'b' # python2
+        source = _open_file_smbprotocol(self.url, mode=mode2, **self.kwargs)
+        try:
+            yield source
+        finally:
+            source.close()
+
+# region SMBHandler
+
+
+def _open_file_smbprotocol(url, mode='rb', **kwargs):
+
+    domain, host, port, user, passwd, server_path = _parse_smb_url(url)
+    import smbclient
+    try:
+        # register the server with explicit credentials
+        if user:
+            session = smbclient.register_session(
+                host, username=user, password=passwd, port=port)
+        # Read an existing file as bytes
+        mode2 = mode[:1] + r'b'
+        filehandle = smbclient.open_file(server_path, mode=mode2, **kwargs)
+        return filehandle
+
+    except Exception as ex:
+        raise ConnectionError('SMB error: %s' %
+                              ex).with_traceback(sys.exc_info()[2])
+
+
+def _parse_smb_url(url):
+    e = 'SMB url must be smb://workgroup;user:password@server:port/share/folder/file.txt: '
+
+    if not url:
+        raise ValueError('SMB error: no host given')
+    elif not url.startswith('smb://'):
+        raise ValueError(e + url)
+
+    if PY3:
+        from urllib.parse import urlparse
+    else:
+        from urlparse import urlparse
+    parsed = urlparse(url)
+    if not parsed.path:
+        raise ValueError(e + url)
+
+    unc_path = parsed.path.replace("/", "\\")
+    server_path = "\\{}{}".format(parsed.hostname, unc_path)
+    if not parsed.username:
+        domain, username = None
+    elif ';' in parsed.username:
+        domain, username = parsed.username.split(';')
+    else:
+        domain, username = None, parsed.username
+    return domain, parsed.hostname, parsed.port or 445, username, parsed.password, server_path
+
+# endregion
+
+
+register_reader('smb', SMBSource)
+register_writer('smb', SMBSource)

--- a/petl/io/text.py
+++ b/petl/io/text.py
@@ -175,7 +175,7 @@ def _writetext(table, source, mode, encoding, errors, template, prologue,
     assert template is not None, 'template is required'
 
     # prepare source
-    source = write_source_from_arg(source)
+    source = write_source_from_arg(source, mode)
 
     with source.open(mode) as buf:
 

--- a/petl/test/io/test_codec.py
+++ b/petl/test/io/test_codec.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+
+import sys
+import os
+from tempfile import NamedTemporaryFile
+
+from petl.compat import PY3
+from petl.test.helpers import ieq
+from petl.io.avro import fromavro, toavro
+from petl.io.csv import fromcsv, tocsv
+from petl.util.vis import look
+
+# region Codec test cases
+
+try:
+    import lzma
+except ImportError as e:
+    print('SKIP XZ codec tests: %s' % e, file=sys.stderr)
+else:
+    def test_lzma():
+        _write_read_with_codec('.xz')
+
+try:
+    import lz4.frame
+except ImportError as e:
+    print('SKIP LZ4 codec tests: %s' % e, file=sys.stderr)
+else:
+    def test_lz4():
+        _write_read_with_codec('.lz4')
+
+try:
+    import zstandard as zstd
+except ImportError as e:
+    print('SKIP ZSTANDARD codec tests: %s' % e, file=sys.stderr)
+else:
+    def test_zstd():
+        _write_read_with_codec('.zstd')
+
+# endregion
+
+# region Execution
+
+
+def _write_read_with_codec(file_ext):
+
+    _table = ((u'name', u'friends', u'age'),
+              (u'Bob', '42', '33'),
+              (u'Jim', '13', '69'),
+              (u'Joe', '86', '17'),
+              (u'Ted', '23', '51'))
+
+    _show__rows_from("Expected:", _table)
+
+    has_avro = _test_avro_too()
+
+    compressed_csv = _get_temp_file_for('.csv' + file_ext)
+    compressed_avr = _get_temp_file_for('.avro' + file_ext)
+
+    tocsv(_table, compressed_csv, encoding='ascii', lineterminator='\n')
+    if PY3:
+        toavro(_table, compressed_avr)
+
+    csv_actual = fromcsv(compressed_csv, encoding='ascii')
+    if PY3:
+        avr_actual = fromavro(compressed_avr)
+
+    _show__rows_from("Actual:", csv_actual)
+    
+    ieq(_table, csv_actual)
+    ieq(_table, csv_actual)  # verify can iterate twice
+    if PY3:
+        ieq(_table, avr_actual)
+        ieq(_table, avr_actual)  # verify can iterate twice
+
+
+def _get_temp_file_for(file_ext):
+    with NamedTemporaryFile(delete=False, mode='wb') as fo:
+        return fo.name + file_ext
+
+
+def _show__rows_from(label, test_rows, limit=0):
+    print(label)
+    print(look(test_rows, limit=limit))
+
+def _test_avro_too():
+    try:
+        import fastavro
+        return True
+    except:
+        return False
+
+# endregion

--- a/petl/test/io/test_codec.py
+++ b/petl/test/io/test_codec.py
@@ -58,18 +58,18 @@ def _write_read_with_codec(file_ext):
     compressed_avr = _get_temp_file_for('.avro' + file_ext)
 
     tocsv(_table, compressed_csv, encoding='ascii', lineterminator='\n')
-    if PY3:
+    if has_avro:
         toavro(_table, compressed_avr)
 
     csv_actual = fromcsv(compressed_csv, encoding='ascii')
-    if PY3:
+    if has_avro:
         avr_actual = fromavro(compressed_avr)
 
     _show__rows_from("Actual:", csv_actual)
     
     ieq(_table, csv_actual)
     ieq(_table, csv_actual)  # verify can iterate twice
-    if PY3:
+    if has_avro:
         ieq(_table, avr_actual)
         ieq(_table, avr_actual)  # verify can iterate twice
 

--- a/petl/test/io/test_codec.py
+++ b/petl/test/io/test_codec.py
@@ -16,25 +16,25 @@ from petl.util.vis import look
 try:
     import lzma
 except ImportError as e:
-    print('SKIP XZ codec tests: %s' % e, file=sys.stderr)
+    print('SKIP XZ helper tests: %s' % e, file=sys.stderr)
 else:
-    def test_lzma():
+    def test_helper_xz():
         _write_read_with_codec('.xz')
 
 try:
     import lz4.frame
 except ImportError as e:
-    print('SKIP LZ4 codec tests: %s' % e, file=sys.stderr)
+    print('SKIP LZ4 helper tests: %s' % e, file=sys.stderr)
 else:
-    def test_lz4():
+    def test_helper_lz4():
         _write_read_with_codec('.lz4')
 
 try:
     import zstandard as zstd
 except ImportError as e:
-    print('SKIP ZSTANDARD codec tests: %s' % e, file=sys.stderr)
+    print('SKIP ZSTANDARD helper tests: %s' % e, file=sys.stderr)
 else:
-    def test_zstd():
+    def test_helper_zstd():
         _write_read_with_codec('.zstd')
 
 # endregion

--- a/petl/test/io/test_source.py
+++ b/petl/test/io/test_source.py
@@ -5,40 +5,49 @@ import sys
 import os
 
 from petl.compat import PY3
-from petl.test.helpers import ieq
+from petl.test.helpers import ieq, eq_
 from petl.io.avro import fromavro, toavro
 from petl.io.csv import fromcsv, tocsv
 from petl.util.vis import look
+
+from petl.io.source.smb import _parse_smb_url
 
 # region Codec test cases
 
 try:
     import s3fs
 except ImportError as e:
-    print('SKIP S3 protocol tests: %s' % e, file=sys.stderr)
+    print('SKIP S3 helper tests: %s' % e, file=sys.stderr)
 else:
-    def test_s3():
+    def test_helper_s3():
         _write_read_from_url('PETL_S3_URL', "export PETL_S3_URL='s3://mybucket/path/folder'")
 
 try:
     import smbclient
 except ImportError as e:
-    print('SKIP SMB protocol tests: %s' % e, file=sys.stderr)
+    print('SKIP SMB helper tests: %s' % e, file=sys.stderr)
 else:
-    def test_smb():
+    def test_helper_smb():
         _write_read_from_url('PETL_SMB_URL', "export PETL_SMB_URL='smb://DOMAIN;myuserID:mypassword@host/share'")
+
+    def test_helper_smb_url_parse():
+        url = r'smb://workgroup;user:password@server:444/share/folder/file.csv'
+        domain, host, port, user, passwd, server_path = _parse_smb_url(url)
+        print("Parsed:", domain, host, port, user, passwd, server_path)
+        eq_(domain, r'workgroup')
+        eq_(host, r'server')
+        eq_(port, 444)
+        eq_(user, r'user')
+        eq_(passwd, r'password')
+        eq_(server_path, "\\\\server\\share\\folder\\file.csv")
 
 # endregion
 
 # region Execution
 
 def _write_read_from_url(env_var_name, example):
+
     base_url = os.getenv(env_var_name, 'skip')
-    if base_url == 'skip':
-        m = "# Skipping test because env var '{}' is not defined. Try this:\n$ {}"
-        msg = m.format(env_var_name, example)
-        print(msg)
-        return
 
     csv_url = os.path.join(base_url, 'filename1.csv')
     gzc_url = os.path.join(base_url, 'filename3.csv.gz')
@@ -52,8 +61,13 @@ def _write_read_from_url(env_var_name, example):
                 (u'Ted', '23', '51'))
 
     _show__rows_from("Expected:", _table)
-
     has_avro = _test_avro_too()
+
+    if base_url == 'skip':
+        m = "# Skipping test because env var '{}' is not defined. Try this:\n$ {}"
+        msg = m.format(env_var_name, example)
+        print(msg)
+        return
 
     tocsv(_table, csv_url, encoding='ascii', lineterminator='\n')
     if PY3:

--- a/petl/test/io/test_source.py
+++ b/petl/test/io/test_source.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+
+import sys
+import os
+
+from petl.compat import PY3
+from petl.test.helpers import ieq
+from petl.io.avro import fromavro, toavro
+from petl.io.csv import fromcsv, tocsv
+from petl.util.vis import look
+
+# region Codec test cases
+
+try:
+    import s3fs
+except ImportError as e:
+    print('SKIP S3 protocol tests: %s' % e, file=sys.stderr)
+else:
+    def test_s3():
+        _write_read_from_url('PETL_S3_URL', "export PETL_S3_URL='s3://mybucket/path/folder'")
+
+try:
+    import smbclient
+except ImportError as e:
+    print('SKIP SMB protocol tests: %s' % e, file=sys.stderr)
+else:
+    def test_smb():
+        _write_read_from_url('PETL_SMB_URL', "export PETL_SMB_URL='smb://DOMAIN;myuserID:mypassword@host/share'")
+
+# endregion
+
+# region Execution
+
+def _write_read_from_url(env_var_name, example):
+    base_url = os.getenv(env_var_name, 'skip')
+    if base_url == 'skip':
+        m = "# Skipping test because env var '{}' is not defined. Try this:\n$ {}"
+        msg = m.format(env_var_name, example)
+        print(msg)
+        return
+
+    csv_url = os.path.join(base_url, 'filename1.csv')
+    gzc_url = os.path.join(base_url, 'filename3.csv.gz')
+    gza_url = os.path.join(base_url, 'filename4.avro.gz')
+    avr_url = os.path.join(base_url, 'filename2.avro')
+
+    _table = ( (u'name', u'friends', u'age'),
+                (u'Bob', '42', '33'),
+                (u'Jim', '13', '69'),
+                (u'Joe', '86', '17'),
+                (u'Ted', '23', '51'))
+
+    _show__rows_from("Expected:", _table)
+
+    has_avro = _test_avro_too()
+
+    tocsv(_table, csv_url, encoding='ascii', lineterminator='\n')
+    if PY3:
+        tocsv(_table, gzc_url, encoding='ascii', lineterminator='\n')
+    if has_avro:
+        toavro(_table, avr_url)
+        if PY3:
+            toavro(_table, gza_url)
+
+    csv_actual = fromcsv(csv_url, encoding='ascii')
+    if PY3:
+        gzp_actual = fromcsv(gzc_url, encoding='ascii')
+    if has_avro:
+        avr_actual = fromavro(avr_url)
+        if PY3:
+            gza_actual = fromavro(gza_url)
+
+    _show__rows_from("Actual:", csv_url)
+
+    ieq(_table, csv_actual)
+    ieq(_table, csv_actual)  # verify can iterate twice
+    if PY3:
+        ieq(_table, gzp_actual)
+        ieq(_table, gzp_actual)  # verify can iterate twice
+    if has_avro:
+        ieq(_table, avr_actual)
+        ieq(_table, avr_actual)  # verify can iterate twice
+        if PY3:
+            ieq(_table, gza_actual)
+            ieq(_table, gza_actual)  # verify can iterate twice
+
+
+def _show__rows_from(label, test_rows, limit=0):
+    print(label)
+    print(look(test_rows, limit=limit))
+
+def _test_avro_too():
+    try:
+        import fastavro
+        return True
+    except:
+        return False
+
+# endregion


### PR DESCRIPTION
## add helpers for xz, lz4 and zstandard codec and for s3 and smb remote servers

### Changes

- Refactored url handling in `to...()` and `from...()` functions for allowing dynamic adding sources.
- Added functions `petl.io.sources.register_reader` and `petl.io.sources.register_writer` for registering custom source helpers for handling I/O from remote protocols.
- Added function `petl.io.sources.register_codec` for registering custom helpers for compressing and decompressing files with other algorithms.
- Added classes `petl.io.codec.xz.XZCodec`, `petl.io.codec.xz.LZ4Codec` and `petl.io.codec.zstd.ZstandardCodec` for compressing files with `XZ` and the "state of art"  `LZ4` and `Zstandard` algorithms.
- Added classes :class:`petl.io.source.s3.S3Source` and `petl.io.source.smb.SMBSource` reading and writing files to remote servers using int url the protocols `s3://` and `smb://`.
- Tested with test suite, AWS S3 and Windows Network Share.

Ready for comments.

### Checklist

* [x] Includes unit tests
* [x] New functions have docstrings with examples that can be run with doctest
* [x] New functions are included in API docs
* [x] Docstrings include notes for any changes to API or behaviour
* [x] Travis CI passes (unit tests run under Linux)
* [x] AppVeyor CI passes (unit tests run under Windows)
* [x] Unit test coverage has not decreased (see Coveralls)
* [x] All changes documented in docs/changes.rst
