### PR TITLE
only override protocol with fsspec when support package is installed

### DIFF
--- a/docs/io.rst
+++ b/docs/io.rst
@@ -406,6 +406,8 @@ For creating custom helpers for :ref:`remote I/O <io_remotes>` or
 
 .. autofunction:: petl.io.sources.register_reader
 .. autofunction:: petl.io.sources.register_writer
+.. autofunction:: petl.io.sources.get_reader
+.. autofunction:: petl.io.sources.get_writer
 
 See the source code of the classes in :mod:`petl.io.sources` module for
 more details.

--- a/petl/io/sources.py
+++ b/petl/io/sources.py
@@ -395,7 +395,7 @@ def get_reader(protocol):
     '''
     Retrieve the handler responsible for reading from a remote protocol.
 
-    .. versionadded:: 1.6.1
+    .. versionadded:: 1.6.0
     '''
 
     _get_handler(protocol, _READERS)
@@ -404,19 +404,10 @@ def get_writer(protocol):
     '''
     Retrieve the handler responsible for writing from a remote protocol.
 
-    .. versionadded:: 1.6.1
+    .. versionadded:: 1.6.0
     '''
 
     _get_handler(protocol, _WRITERS)
-
-def get_codec(protocol):
-    '''
-    Retrieve the handler responsible for compression and decompression for a local file.
-
-    .. versionadded:: 1.6.1
-    '''
-
-    _get_handler(protocol, _CODECS)
 
 
 # Setup default sources

--- a/petl/io/sources.py
+++ b/petl/io/sources.py
@@ -344,6 +344,14 @@ def _register_handler(handler_type, handler_class, handler_list):
     handler_list[handler_type] = handler_class
 
 
+def _get_handler(handler_type, handler_list):
+
+    if isinstance(handler_type, string_types):
+        if handler_type in handler_list:
+            return handler_list[handler_type]
+    return None
+
+
 def register_codec(extension, handler_class):
     '''
     Register handler for automatic compression and decompression for file I/O
@@ -381,6 +389,35 @@ def register_writer(protocol, handler_class):
     '''
 
     _register_handler(protocol, handler_class, _WRITERS)
+
+
+def get_reader(protocol):
+    '''
+    Retrieve the handler responsible for reading from a remote protocol.
+
+    .. versionadded:: 1.6.1
+    '''
+
+    _get_handler(protocol, _READERS)
+
+def get_writer(protocol):
+    '''
+    Retrieve the handler responsible for writing from a remote protocol.
+
+    .. versionadded:: 1.6.1
+    '''
+
+    _get_handler(protocol, _WRITERS)
+
+def get_codec(protocol):
+    '''
+    Retrieve the handler responsible for compression and decompression for a local file.
+
+    .. versionadded:: 1.6.1
+    '''
+
+    _get_handler(protocol, _CODECS)
+
 
 # Setup default sources
     


### PR DESCRIPTION
# Changes

1. add get_reader() and get_writer() functions for checking if there is a protocol handler
2. when registering with `fsspec` don't override a protocol if the fsspec says that the supporting package is not installed
3. let `fsspec` handle `http` and `https` protocols when `requests` package is installed. This allows using compressions like `zstandard`, `xz`, `lz4`. with this protocols.

* [x] Includes unit tests
* [x] New functions have docstrings with examples that can be run with doctest
* [x] New functions are included in API docs
* [x] Docstrings include notes for any changes to API or behaviour
* [x] Travis CI passes (unit tests run under Linux)
* [x] AppVeyor CI passes (unit tests run under Windows)
* [x] Unit test coverage has not decreased (see Coveralls)
* [x] All changes documented in docs/changes.rst
