### PR TITLE
Allow toxlsx() to add or replace a worksheet.

### DIFF
--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, print_function, division
 
 
+import os
 import locale
 
 
@@ -86,15 +87,32 @@ class XLSXView(Table):
             pass
 
 
-def toxlsx(tbl, filename, sheet=None, write_header=True):
+def toxlsx(tbl, filename, sheet=None, write_header=True, overwrite=True):
     """
     Write a table to a new Excel .xlsx file.
+
+    N.B., the sheet name is case sensitive.
+
+    The `sheet` argument can be omitted, the new sheet will then get a
+    default name.
+
+    If `overwrite` is True, the contents of the file will be replaced
+    with a single sheet. If the argument is False and the file already
+    exists, an existing sheet of the same name will be replaced or a
+    new sheet added at the end.
 
     """
 
     import openpyxl
-    wb = openpyxl.Workbook(write_only=True)
-    ws = wb.create_sheet(title=sheet)
+    if not overwrite and os.path.exists(filename):
+        wb = openpyxl.load_workbook(filename=filename, read_only=False)
+    else:
+        wb = openpyxl.Workbook(write_only=True)
+    if sheet in wb.sheetnames:
+        ws = wb[str(sheet)]
+        ws.delete_rows(1, ws.max_row)
+    else:
+        ws = wb.create_sheet(title=sheet)
     if write_header:
         rows = tbl
     else:

--- a/petl/test/io/test_xlsx.py
+++ b/petl/test/io/test_xlsx.py
@@ -92,6 +92,23 @@ else:
         expect = etl.cat(tbl, tbl)
         ieq(expect, actual)
 
+    def test_toxlsx_nooverwrite():
+        tbl = (('foo', 'bar'),
+               ('A', 1),
+               ('B', 2),
+               ('C', 2),
+               (u'é', datetime(2012, 1, 1)))
+        f = NamedTemporaryFile(delete=False, suffix='.xlsx')
+        f.close()
+
+        # test toxlsx
+        toxlsx(tbl, f.name, 'Sheet1')
+        toxlsx(tbl, f.name, 'Sheet2', overwrite=False)
+        actual = fromxlsx(f.name, 'Sheet1')
+        ieq(tbl, actual)
+        actual = fromxlsx(f.name, 'Sheet2')
+        ieq(tbl, actual)
+
     def test_toxlsx_nosheet():
         tbl = (('foo', 'bar'),
                ('A', 1),

--- a/petl/test/io/test_xlsx.py
+++ b/petl/test/io/test_xlsx.py
@@ -79,7 +79,7 @@ else:
                ('B', 2),
                ('C', 2),
                (u'é', datetime(2012, 1, 1)))
-        f = NamedTemporaryFile(delete=False, suffix='.xlsx')
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
         f.close()
 
         # test toxlsx
@@ -129,6 +129,19 @@ else:
         f.close()
 
         toxlsx(tbl, f.name, 'Sheet1', mode="overwrite")
+        toxlsx(tbl, f.name, 'Sheet1', mode="replace")
+        wb = openpyxl.load_workbook(f.name, read_only=True)
+        eq_(1, len(wb.sheetnames))
+
+    def test_toxlsx_replace_sheet_nofile():
+        tbl = (('foo', 'bar'),
+               ('A', 1),
+               ('B', 2),
+               ('C', 2),
+               (u'é', datetime(2012, 1, 1)))
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
+        f.close()
+
         toxlsx(tbl, f.name, 'Sheet1', mode="replace")
         wb = openpyxl.load_workbook(f.name, read_only=True)
         eq_(1, len(wb.sheetnames))
@@ -195,7 +208,7 @@ else:
                ('B', 2),
                ('C', 2),
                (u'é', datetime(2012, 1, 1)))
-        f = NamedTemporaryFile(delete=False, suffix='.xlsx')
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
         f.close()
         tbl = etl.wrap(tbl)
         tbl.toxlsx(f.name, 'Sheet1')


### PR DESCRIPTION
This PR has the objective of enabling toxlsx() to be used to produce xlsx files with multiple worksheets.

The single unit test I added is successful, but I was not able to get the entire test suite to run.

## Changes

1. Added the `overwrite` argument to io.xlsx.toxlsx() and added a minimal docstring.

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [ ] Code
  * [x] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [x] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes documented in docs/changes.rst
* [x] Testing
  * [x] \(Optional) Tested local against remote servers
  * [x] Travis CI passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [ ] \(Optional) Just a proof of concept
  * [ ] \(Optional) Work in progress
  * [x] Ready to review
  * [ ] Ready to merge
