### PR TITLE
Downgraded another unavoidable warning to debug

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Version 1.6.2
+-------------
+
+* Fix unavoidable warning if fsspec is installed but some optional package is
+  not installed.
+  By :user:`juarezr`, :issue:`502`.
+
+
 Version 1.6.1
 -------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,7 +6,7 @@ Version 1.6.2
 
 * Fix unavoidable warning if fsspec is installed but some optional package is
   not installed.
-  By :user:`juarezr`, :issue:`502`.
+  By :user:`juarezr`, :issue:`503`.
 
 
 Version 1.6.1

--- a/petl/io/remotes.py
+++ b/petl/io/remotes.py
@@ -103,7 +103,7 @@ def _register_filesystems(only_available=False):
     for protocol, spec in impls:
         if "err" in spec:
             emsg = "# WARN: fsspec {} unavailable: {}".format(protocol, spec["err"])
-            logger.warning(emsg)
+            logger.debug(emsg)
             if only_available:
                 # otherwise foward the exception on first use when the 
                 # handler can show what package is missing


### PR DESCRIPTION
This PR fixes another annoying warning introduced in 1.6.

## Changes

1. Downgraded unavoidable `warning` to `debug`if `fsspec` is installed but some optional package is not installed.
2. Mentioned in changes.rst

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [x] Code
  * [ ] ~~Includes unit tests~~
  * [x] All changes documented in docs/changes.rst
* [x] Testing
  * [x] Travis CI passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [x] Ready to review
  * [x] Ready to merge
