### PR TITLE
Allow reading and writing Excel files in remote sources

### DIFF
--- a/petl/io/__init__.py
+++ b/petl/io/__init__.py
@@ -23,7 +23,7 @@ from petl.io.db import fromdb, todb, appenddb
 
 from petl.io.xls import fromxls, toxls
 
-from petl.io.xlsx import fromxlsx, toxlsx
+from petl.io.xlsx import fromxlsx, toxlsx, appendxlsx
 
 from petl.io.numpy import fromarray, toarray, torecarray
 

--- a/petl/io/xls.py
+++ b/petl/io/xls.py
@@ -5,8 +5,9 @@ from __future__ import division, print_function, absolute_import
 import locale
 
 
-from petl.compat import izip_longest, next, xrange
+from petl.compat import izip_longest, next, xrange, BytesIO
 from petl.util.base import Table
+from petl.io.sources import read_source_from_arg, write_source_from_arg
 
 
 def fromxls(filename, sheet=None, use_view=True, **kwargs):
@@ -36,26 +37,31 @@ class XLSView(Table):
         # converted
         if self.use_view:
             from petl.io import xlutils_view
-            wb = xlutils_view.View(self.filename)
-            if self.sheet is None:
-                ws = wb[0]
-            else:
-                ws = wb[self.sheet]
-            for row in ws:
-                yield tuple(row)
-
+            source = read_source_from_arg(self.filename)
+            with source.open('rb') as source2:
+                source3 = source2.read()
+                wb = xlutils_view.View(source3)
+                if self.sheet is None:
+                    ws = wb[0]
+                else:
+                    ws = wb[self.sheet]
+                for row in ws:
+                    yield tuple(row)
         else:
             import xlrd
-            with xlrd.open_workbook(filename=self.filename,
-                                    on_demand=True, **self.kwargs) as wb:
-                if self.sheet is None:
-                    ws = wb.sheet_by_index(0)
-                elif isinstance(self.sheet, int):
-                    ws = wb.sheet_by_index(self.sheet)
-                else:
-                    ws = wb.sheet_by_name(str(self.sheet))
-                for rownum in xrange(ws.nrows):
-                    yield tuple(ws.row_values(rownum))
+            source = read_source_from_arg(self.filename)
+            with source.open('rb') as source2:
+                source3 = source2.read()
+                with xlrd.open_workbook(file_contents=source3,
+                                        on_demand=True, **self.kwargs) as wb:
+                    if self.sheet is None:
+                        ws = wb.sheet_by_index(0)
+                    elif isinstance(self.sheet, int):
+                        ws = wb.sheet_by_index(self.sheet)
+                    else:
+                        ws = wb.sheet_by_name(str(self.sheet))
+                    for rownum in xrange(ws.nrows):
+                        yield tuple(ws.row_values(rownum))
 
 
 def toxls(tbl, filename, sheet, encoding=None, style_compression=0,
@@ -92,7 +98,9 @@ def toxls(tbl, filename, sheet, encoding=None, style_compression=0,
                                                         fillvalue=None)):
                 ws.write(r+1, c, label=v, style=style)
 
-    wb.save(filename)
+    target = write_source_from_arg(filename)
+    with target.open('wb') as target2:
+        wb.save(target2)
 
 
 Table.toxls = toxls

--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 
-
 import locale
 
-
 from petl.util.base import Table, data
+from petl.io.sources import read_source_from_arg, write_source_from_arg
 
 
 def fromxlsx(filename, sheet=None, range_string=None, min_row=None,
@@ -58,9 +57,11 @@ class XLSXView(Table):
 
     def __iter__(self):
         import openpyxl
-        wb = openpyxl.load_workbook(filename=self.filename,
-                                    read_only=self.read_only,
-                                    **self.kwargs)
+        source = read_source_from_arg(self.filename)
+        with source.open('rb') as source2:
+            wb = openpyxl.load_workbook(filename=source2,
+                                        read_only=self.read_only,
+                                        **self.kwargs)
         if self.sheet is None:
             ws = wb[wb.sheetnames[0]]
         elif isinstance(self.sheet, int):
@@ -101,7 +102,9 @@ def toxlsx(tbl, filename, sheet=None, write_header=True):
         rows = data(tbl)
     for row in rows:
         ws.append(row)
-    wb.save(filename)
+    target = write_source_from_arg(filename)
+    with target.open('wb') as target2:
+        wb.save(target2)
 
 
 Table.toxlsx = toxlsx
@@ -113,7 +116,9 @@ def appendxlsx(tbl, filename, sheet=None, write_header=False):
     """
 
     import openpyxl
-    wb = openpyxl.load_workbook(filename=filename, read_only=False)
+    source = read_source_from_arg(filename)
+    with source.open('rb') as source2:
+        wb = openpyxl.load_workbook(filename=source2, read_only=False)
     if sheet is None:
         ws = wb[wb.sheetnames[0]]
     elif isinstance(sheet, int):
@@ -126,7 +131,9 @@ def appendxlsx(tbl, filename, sheet=None, write_header=False):
         rows = data(tbl)
     for row in rows:
         ws.append(row)
-    wb.save(filename)
+    target = write_source_from_arg(filename)
+    with target.open('wb') as target2:
+        wb.save(target2)
 
 
 Table.appendxlsx = appendxlsx

--- a/petl/io/xlutils_view.py
+++ b/petl/io/xlutils_view.py
@@ -111,10 +111,11 @@ class View(object):
     #: :class:`SheetView` for the views of sheets returned.
     class_ = SheetView
 
-    def __init__(self, path, class_=None):
+    def __init__(self, file_contents, class_=None, **kwargs):
         self.class_ = class_ or self.class_
         from xlrd import open_workbook
-        self.book = open_workbook(path, formatting_info=0, on_demand=True)
+        self.book = open_workbook(file_contents=file_contents, 
+                                  on_demand=True, **kwargs)
 
     def __getitem__(self, item):
         """


### PR DESCRIPTION
Today the excel implementation only allows reading and writing Excel files in the local filesystem.
Other formats like `avro`, `csv`, `json`, `text` already support reading from remote servers/cloud using `fsspec` package.
This improves the current implementation for allowing opening remote `xls` and `xlsx` files when using `fsspec`.

## Changes

1. Changed `fromxls()` and `toxls()` to call `read_source_from_arg` or `write_source_from_arg`. 
2. Changed `fromxlsx()`, `toxlsx()` and `appendxlsx()` to call `read_source_from_arg` or `write_source_from_arg`. 
3. Added tests for testing remote testing of the `xls` and `xlsx` file formats.
4. Added `appendxlsx()`  to `init.py` making it public
5. Tested with `S3` remote source.

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [x] Code
  * [x] Includes unit tests
  * [x] ~~New functions have docstrings with examples that can be run with doctest~~
  * [x] ~~New functions are included in API docs~~
  * [x] ~~Docstrings include notes for any changes to API or behaviour~~
  * [x] ~~All changes documented in docs/changes.rst~~
* [x] Testing
  * [x] \(Optional) Tested local against remote servers
  * [x] Travis CI passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [x] Ready to review
  * [x] Ready to merge
