### PR TITLE
Allow toxlsx() to overwrite add or replace a worksheet

### DIFF
--- a/petl/io/__init__.py
+++ b/petl/io/__init__.py
@@ -23,7 +23,7 @@ from petl.io.db import fromdb, todb, appenddb
 
 from petl.io.xls import fromxls, toxls
 
-from petl.io.xlsx import fromxlsx, toxlsx
+from petl.io.xlsx import fromxlsx, toxlsx, appendxlsx
 
 from petl.io.numpy import fromarray, toarray, torecarray
 

--- a/petl/io/xls.py
+++ b/petl/io/xls.py
@@ -5,8 +5,9 @@ from __future__ import division, print_function, absolute_import
 import locale
 
 
-from petl.compat import izip_longest, next, xrange
+from petl.compat import izip_longest, next, xrange, BytesIO
 from petl.util.base import Table
+from petl.io.sources import read_source_from_arg, write_source_from_arg
 
 
 def fromxls(filename, sheet=None, use_view=True, **kwargs):
@@ -36,26 +37,31 @@ class XLSView(Table):
         # converted
         if self.use_view:
             from petl.io import xlutils_view
-            wb = xlutils_view.View(self.filename)
-            if self.sheet is None:
-                ws = wb[0]
-            else:
-                ws = wb[self.sheet]
-            for row in ws:
-                yield tuple(row)
-
+            source = read_source_from_arg(self.filename)
+            with source.open('rb') as source2:
+                source3 = source2.read()
+                wb = xlutils_view.View(source3)
+                if self.sheet is None:
+                    ws = wb[0]
+                else:
+                    ws = wb[self.sheet]
+                for row in ws:
+                    yield tuple(row)
         else:
             import xlrd
-            with xlrd.open_workbook(filename=self.filename,
-                                    on_demand=True, **self.kwargs) as wb:
-                if self.sheet is None:
-                    ws = wb.sheet_by_index(0)
-                elif isinstance(self.sheet, int):
-                    ws = wb.sheet_by_index(self.sheet)
-                else:
-                    ws = wb.sheet_by_name(str(self.sheet))
-                for rownum in xrange(ws.nrows):
-                    yield tuple(ws.row_values(rownum))
+            source = read_source_from_arg(self.filename)
+            with source.open('rb') as source2:
+                source3 = source2.read()
+                with xlrd.open_workbook(file_contents=source3,
+                                        on_demand=True, **self.kwargs) as wb:
+                    if self.sheet is None:
+                        ws = wb.sheet_by_index(0)
+                    elif isinstance(self.sheet, int):
+                        ws = wb.sheet_by_index(self.sheet)
+                    else:
+                        ws = wb.sheet_by_name(str(self.sheet))
+                    for rownum in xrange(ws.nrows):
+                        yield tuple(ws.row_values(rownum))
 
 
 def toxls(tbl, filename, sheet, encoding=None, style_compression=0,
@@ -92,7 +98,9 @@ def toxls(tbl, filename, sheet, encoding=None, style_compression=0,
                                                         fillvalue=None)):
                 ws.write(r+1, c, label=v, style=style)
 
-    wb.save(filename)
+    target = write_source_from_arg(filename)
+    with target.open('wb') as target2:
+        wb.save(target2)
 
 
 Table.toxls = toxls

--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 
-import locale
-
+from petl.compat import PY3
 from petl.util.base import Table, data
 from petl.io.sources import read_source_from_arg, write_source_from_arg
 
@@ -87,15 +86,52 @@ class XLSXView(Table):
             pass
 
 
-def toxlsx(tbl, filename, sheet=None, write_header=True):
+def toxlsx(tbl, filename, sheet=None, write_header=True, mode="replace"):
     """
     Write a table to a new Excel .xlsx file.
 
-    """
+    N.B., the sheet name is case sensitive.
+    The `mode` argument controls how the file and sheet are treated:
+    - `replace`: This is the default. It either replaces or adds a
+      named sheet, or if no sheet name is provided, all sheets
+      (overwrites the entire file).
+    - `overwrite`: Always overwrites the file. This produces a file
+      with a single sheet.
+    - `add`: Adds a new sheet. Raises `ValueError` if a named sheet
+      already exists.
+    The `sheet` argument can be omitted in all cases. The new sheet
+    will then get a default name.
+    If the file does not exist, it will be created, unless `replace`
+    mode is used with a named sheet. In the latter case, the file
+    must exist and be a valid .xlsx file.
 
+    """
     import openpyxl
-    wb = openpyxl.Workbook(write_only=True)
-    ws = wb.create_sheet(title=sheet)
+    if mode == "overwrite" or (mode == "replace" and sheet is None):
+        wb = openpyxl.Workbook(write_only=True)
+        ws = wb.create_sheet(title=sheet)
+    elif mode == "replace":
+        if PY3:
+            FileNotFound = FileNotFoundError
+        else:
+            FileNotFound = IOError
+        try:
+            wb = openpyxl.load_workbook(filename=filename, read_only=False)
+        except FileNotFound:
+            wb = openpyxl.Workbook(write_only=True)
+        try:
+            ws = wb[str(sheet)]
+            ws.delete_rows(1, ws.max_row)
+        except KeyError:
+            ws = wb.create_sheet(title=sheet)
+    elif mode == "add":
+        wb = openpyxl.load_workbook(filename=filename, read_only=False)
+        ws = wb.create_sheet(title=sheet)
+        # wb.create_sheet(title="foo") creates "foo1" if "foo" exists.
+        if sheet is not None and ws.title != sheet:
+            raise ValueError("Sheet %s already exists in file" % sheet)
+    else:
+        raise ValueError("Unknown mode '%s'" % mode)
     if write_header:
         rows = tbl
     else:

--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -91,20 +91,24 @@ def toxlsx(tbl, filename, sheet=None, write_header=True, mode="replace"):
     Write a table to a new Excel .xlsx file.
 
     N.B., the sheet name is case sensitive.
+
     The `mode` argument controls how the file and sheet are treated:
-    - `replace`: This is the default. It either replaces or adds a
-      named sheet, or if no sheet name is provided, all sheets
-      (overwrites the entire file).
-    - `overwrite`: Always overwrites the file. This produces a file
-      with a single sheet.
-    - `add`: Adds a new sheet. Raises `ValueError` if a named sheet
-      already exists.
+
+      - `replace`: This is the default. It either replaces or adds a
+        named sheet, or if no sheet name is provided, all sheets
+        (overwrites the entire file).
+
+      - `overwrite`: Always overwrites the file. This produces a file
+        with a single sheet.
+
+      - `add`: Adds a new sheet. Raises `ValueError` if a named sheet
+        already exists.
+
     The `sheet` argument can be omitted in all cases. The new sheet
     will then get a default name.
     If the file does not exist, it will be created, unless `replace`
     mode is used with a named sheet. In the latter case, the file
     must exist and be a valid .xlsx file.
-
     """
     import openpyxl
     if mode == "overwrite" or (mode == "replace" and sheet is None):

--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 
-
 import locale
 
-
 from petl.util.base import Table, data
+from petl.io.sources import read_source_from_arg, write_source_from_arg
 
 
 def fromxlsx(filename, sheet=None, range_string=None, min_row=None,
@@ -58,9 +57,11 @@ class XLSXView(Table):
 
     def __iter__(self):
         import openpyxl
-        wb = openpyxl.load_workbook(filename=self.filename,
-                                    read_only=self.read_only,
-                                    **self.kwargs)
+        source = read_source_from_arg(self.filename)
+        with source.open('rb') as source2:
+            wb = openpyxl.load_workbook(filename=source2,
+                                        read_only=self.read_only,
+                                        **self.kwargs)
         if self.sheet is None:
             ws = wb[wb.sheetnames[0]]
         elif isinstance(self.sheet, int):
@@ -101,7 +102,9 @@ def toxlsx(tbl, filename, sheet=None, write_header=True):
         rows = data(tbl)
     for row in rows:
         ws.append(row)
-    wb.save(filename)
+    target = write_source_from_arg(filename)
+    with target.open('wb') as target2:
+        wb.save(target2)
 
 
 Table.toxlsx = toxlsx
@@ -113,7 +116,9 @@ def appendxlsx(tbl, filename, sheet=None, write_header=False):
     """
 
     import openpyxl
-    wb = openpyxl.load_workbook(filename=filename, read_only=False)
+    source = read_source_from_arg(filename)
+    with source.open('rb') as source2:
+        wb = openpyxl.load_workbook(filename=source2, read_only=False)
     if sheet is None:
         ws = wb[wb.sheetnames[0]]
     elif isinstance(sheet, int):
@@ -126,7 +131,9 @@ def appendxlsx(tbl, filename, sheet=None, write_header=False):
         rows = data(tbl)
     for row in rows:
         ws.append(row)
-    wb.save(filename)
+    target = write_source_from_arg(filename)
+    with target.open('wb') as target2:
+        wb.save(target2)
 
 
 Table.appendxlsx = appendxlsx

--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -131,7 +131,7 @@ def _load_or_create_workbook(filename, mode, sheet):
 
     import openpyxl
     wb = None
-    if mode != "overwrite" and (mode != "replace" or sheet is not None):
+    if not (mode == "overwrite" or (mode == "replace" and sheet is None)):
         try:
             source = read_source_from_arg(filename)
             with source.open('rb') as source2:

--- a/petl/io/xlutils_view.py
+++ b/petl/io/xlutils_view.py
@@ -111,10 +111,11 @@ class View(object):
     #: :class:`SheetView` for the views of sheets returned.
     class_ = SheetView
 
-    def __init__(self, path, class_=None):
+    def __init__(self, file_contents, class_=None, **kwargs):
         self.class_ = class_ or self.class_
         from xlrd import open_workbook
-        self.book = open_workbook(path, formatting_info=0, on_demand=True)
+        self.book = open_workbook(file_contents=file_contents, 
+                                  on_demand=True, **kwargs)
 
     def __getitem__(self, item):
         """

--- a/petl/test/io/test_remotes.py
+++ b/petl/test/io/test_remotes.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function, division
 
 import sys
 import os
+import time
 from importlib import import_module
 
 from petl.compat import PY3
@@ -87,17 +88,17 @@ def _write_read_from_env_url(env_var_name):
 
 
 def _write_read_into_url(base_url):
-    _write_read_file_into_url(base_url, "filename10.csv")
-    _write_read_file_into_url(base_url, "filename11.csv", "gz")
-    _write_read_file_into_url(base_url, "filename12.csv", "xz")
-    _write_read_file_into_url(base_url, "filename13.csv", "zst")
-    _write_read_file_into_url(base_url, "filename14.csv", "lz4")
-    _write_read_file_into_url(base_url, "filename15.csv", "snappy")
-    _write_read_file_into_url(base_url, "filename20.json")
-    _write_read_file_into_url(base_url, "filename21.json", "gz")
-    _write_read_file_into_url(base_url, "filename30.avro", pkg='fastavro')
+    # _write_read_file_into_url(base_url, "filename10.csv")
+    # _write_read_file_into_url(base_url, "filename11.csv", "gz")
+    # _write_read_file_into_url(base_url, "filename12.csv", "xz")
+    # _write_read_file_into_url(base_url, "filename13.csv", "zst")
+    # _write_read_file_into_url(base_url, "filename14.csv", "lz4")
+    # _write_read_file_into_url(base_url, "filename15.csv", "snappy")
+    # _write_read_file_into_url(base_url, "filename20.json")
+    # _write_read_file_into_url(base_url, "filename21.json", "gz")
+    # _write_read_file_into_url(base_url, "filename30.avro", pkg='fastavro')
     _write_read_file_into_url(base_url, "filename40.xlsx", pkg='openpyxl')
-    _write_read_file_into_url(base_url, "filename50.xls", pkg='xlwt')
+    # _write_read_file_into_url(base_url, "filename50.xls", pkg='xlwt')
 
 
 def _write_read_file_into_url(base_url, filename, compression=None, pkg=None):
@@ -126,8 +127,9 @@ def _write_read_file_into_url(base_url, filename, compression=None, pkg=None):
         toavro(_table, source_url)
         actual = fromavro(source_url)
     elif ".xlsx" in filename:
-        toxlsx(_table, source_url, 'test')
-        actual = fromxlsx(source_url, 'test')
+        toxlsx(_table, source_url, 'test1', mode='overwrite')
+        toxlsx(_table2, source_url, 'test2', mode='add')
+        actual = fromxlsx(source_url, 'test1')
     elif ".xls" in filename:
         toxls(_table, source_url, 'test')
         actual = fromxls(source_url, 'test')
@@ -171,6 +173,14 @@ _table = (
     (u"Jim", "13", "69"),
     (u"Joe", "86", "17"),
     (u"Ted", "23", "51"),
+)
+
+_table2 = (
+    (u"name", u"friends", u"age"),
+    (u"Giannis", "31", "12"),
+    (u"James", "38", "8"),
+    (u"Stephen", "28", "4"),
+    (u"Jason", "23", "12"),
 )
 
 # endregion

--- a/petl/test/io/test_remotes.py
+++ b/petl/test/io/test_remotes.py
@@ -88,17 +88,17 @@ def _write_read_from_env_url(env_var_name):
 
 
 def _write_read_into_url(base_url):
-    # _write_read_file_into_url(base_url, "filename10.csv")
-    # _write_read_file_into_url(base_url, "filename11.csv", "gz")
-    # _write_read_file_into_url(base_url, "filename12.csv", "xz")
-    # _write_read_file_into_url(base_url, "filename13.csv", "zst")
-    # _write_read_file_into_url(base_url, "filename14.csv", "lz4")
-    # _write_read_file_into_url(base_url, "filename15.csv", "snappy")
-    # _write_read_file_into_url(base_url, "filename20.json")
-    # _write_read_file_into_url(base_url, "filename21.json", "gz")
-    # _write_read_file_into_url(base_url, "filename30.avro", pkg='fastavro')
+    _write_read_file_into_url(base_url, "filename10.csv")
+    _write_read_file_into_url(base_url, "filename11.csv", "gz")
+    _write_read_file_into_url(base_url, "filename12.csv", "xz")
+    _write_read_file_into_url(base_url, "filename13.csv", "zst")
+    _write_read_file_into_url(base_url, "filename14.csv", "lz4")
+    _write_read_file_into_url(base_url, "filename15.csv", "snappy")
+    _write_read_file_into_url(base_url, "filename20.json")
+    _write_read_file_into_url(base_url, "filename21.json", "gz")
+    _write_read_file_into_url(base_url, "filename30.avro", pkg='fastavro')
     _write_read_file_into_url(base_url, "filename40.xlsx", pkg='openpyxl')
-    # _write_read_file_into_url(base_url, "filename50.xls", pkg='xlwt')
+    _write_read_file_into_url(base_url, "filename50.xls", pkg='xlwt')
 
 
 def _write_read_file_into_url(base_url, filename, compression=None, pkg=None):

--- a/petl/test/io/test_remotes.py
+++ b/petl/test/io/test_remotes.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function, division
 
 import sys
 import os
-import time
 from importlib import import_module
 
 from petl.compat import PY3

--- a/petl/test/io/test_xlsx.py
+++ b/petl/test/io/test_xlsx.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import, print_function, division
 
 
 import sys
-import pkg_resources
 from datetime import datetime
 from tempfile import NamedTemporaryFile
 
+import pkg_resources
 
 import petl as etl
 from petl.io.xlsx import fromxlsx, toxlsx, appendxlsx
-from petl.test.helpers import ieq
+from petl.test.helpers import ieq, eq_
 
 
 try:
@@ -79,7 +79,7 @@ else:
                ('B', 2),
                ('C', 2),
                (u'é', datetime(2012, 1, 1)))
-        f = NamedTemporaryFile(delete=False, suffix='.xlsx')
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
         f.close()
 
         # test toxlsx
@@ -98,7 +98,7 @@ else:
                ('B', 2),
                ('C', 2),
                (u'é', datetime(2012, 1, 1)))
-        f = NamedTemporaryFile(delete=False, suffix='.xlsx')
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
         f.close()
         toxlsx(tbl, f.name)
         actual = fromxlsx(f.name)
@@ -110,7 +110,7 @@ else:
                ('B', 2),
                ('C', 2),
                (u'é', datetime(2012, 1, 1)))
-        f = NamedTemporaryFile(delete=False, suffix='.xlsx')
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
         f.close()
         tbl = etl.wrap(tbl)
         tbl.toxlsx(f.name, 'Sheet1')
@@ -120,3 +120,100 @@ else:
         expect = tbl.cat(tbl)
         ieq(expect, actual)
 
+    def test_toxlsx_overwrite():
+        tbl = (('foo', 'bar'),
+               ('A', 1),
+               ('B', 2),
+               ('C', 2),
+               (u'é', datetime(2012, 1, 1)))
+        f = NamedTemporaryFile(delete=False, suffix='.xlsx')
+        f.close()
+
+        toxlsx(tbl, f.name, 'Sheet1', mode="overwrite")
+        wb = openpyxl.load_workbook(f.name, read_only=True)
+        eq_(1, len(wb.sheetnames))
+
+    def test_toxlsx_replace_file():
+        tbl = (('foo', 'bar'),
+               ('A', 1),
+               ('B', 2),
+               ('C', 2),
+               (u'é', datetime(2012, 1, 1)))
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
+        f.close()
+
+        toxlsx(tbl, f.name, 'Sheet1', mode="overwrite")
+        toxlsx(tbl, f.name, sheet=None, mode="replace")
+        wb = openpyxl.load_workbook(f.name, read_only=True)
+        eq_(1, len(wb.sheetnames))
+
+    def test_toxlsx_replace_sheet():
+        tbl = (('foo', 'bar'),
+               ('A', 1),
+               ('B', 2),
+               ('C', 2),
+               (u'é', datetime(2012, 1, 1)))
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
+        f.close()
+
+        toxlsx(tbl, f.name, 'Sheet1', mode="overwrite")
+        toxlsx(tbl, f.name, 'Sheet1', mode="replace")
+        wb = openpyxl.load_workbook(f.name, read_only=True)
+        eq_(1, len(wb.sheetnames))
+
+    def test_toxlsx_replace_sheet_nofile():
+        tbl = (('foo', 'bar'),
+               ('A', 1),
+               ('B', 2),
+               ('C', 2),
+               (u'é', datetime(2012, 1, 1)))
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
+        f.close()
+
+        toxlsx(tbl, f.name, 'Sheet1', mode="replace")
+        wb = openpyxl.load_workbook(f.name, read_only=True)
+        eq_(1, len(wb.sheetnames))
+
+    def test_toxlsx_add_nosheet():
+        tbl = (('foo', 'bar'),
+               ('A', 1),
+               ('B', 2),
+               ('C', 2),
+               (u'é', datetime(2012, 1, 1)))
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
+        f.close()
+
+        toxlsx(tbl, f.name, 'Sheet1', mode="overwrite")
+        toxlsx(tbl, f.name, None, mode="add")
+        wb = openpyxl.load_workbook(f.name, read_only=True)
+        eq_(2, len(wb.sheetnames))
+
+    def test_toxlsx_add_sheet_nomatch():
+        tbl = (('foo', 'bar'),
+               ('A', 1),
+               ('B', 2),
+               ('C', 2),
+               (u'é', datetime(2012, 1, 1)))
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
+        f.close()
+
+        toxlsx(tbl, f.name, 'Sheet1', mode="overwrite")
+        toxlsx(tbl, f.name, 'Sheet2', mode="add")
+        wb = openpyxl.load_workbook(f.name, read_only=True)
+        eq_(2, len(wb.sheetnames))
+
+    def test_toxlsx_add_sheet_match():
+        tbl = (('foo', 'bar'),
+               ('A', 1),
+               ('B', 2),
+               ('C', 2),
+               (u'é', datetime(2012, 1, 1)))
+        f = NamedTemporaryFile(delete=True, suffix='.xlsx')
+        f.close()
+
+        toxlsx(tbl, f.name, 'Sheet1', mode="overwrite")
+        try:
+            toxlsx(tbl, f.name, 'Sheet1', mode="add")
+            assert False, 'Adding duplicate sheet name did not fail'
+        except ValueError:
+            pass


### PR DESCRIPTION
This PR is the same as #502 but rebased on top of #506 

## Changes

1. Added new parameter `mode` to `toxlsx()` from $502
2. Rebased on top of #506
3. Removed a call to `os.path.exists()` as it wont work with remote sources from `fsspec`

## Checklist

* [x] Code
  * [x] Includes unit tests
  * [x] New functions have docstrings with examples that can be run with doctest
  * [x] New functions are included in API docs
  * [x] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes documented in docs/changes.rst
* [x] Testing
  * [x] \(Optional) Tested local against remote servers
  * [x] Travis CI passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [x] Ready to review
  * [x] Ready to merge
