### PR TITLE
fix exception when writing to S3 with fsspec and auto_mkdir=True

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+Version 1.6.4
+-------------
+
+* Fixed exception when writing to S3 with ``fsspec`` ``auto_mkdir=True``.
+  By :user:`juarezr`, :issue:`512`.
+
+
 Version 1.6.3
 -------------
 

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -10,7 +10,8 @@ SQLAlchemy==1.3.6
 Whoosh==2.7.4
 xlrd==1.2.0
 xlwt==1.3.0
-fastavro>=0.24
+fastavro>=0.24.2 ; python_version >= '3.4'
+fastavro==0.24.2 ; python_version < '3.0'
 smbprotocol>=1.0.1
 requests; python_version >= '3.4'
 fsspec>=0.7.4 ; python_version >= '3.4'


### PR DESCRIPTION
This PR has the objective of fixing a bug when writing to S3.

This is caused by the dependent lib `fsspec` because it has a parameter `auto_mkdir=True` for creating folders automatically.

## Changes

1. Fixed the `fsspec` call passing `auto_mkdir=False`.
2. This causes the default behavior being of not to create the folders when missing.

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [x] Code
  * [x] All changes documented in docs/changes.rst
* [x] Testing
  * [x] \(Optional) Tested local against remote servers
  * [ ] Travis CI passes (unit tests run under Linux)
  * [ ] AppVeyor CI passes (unit tests run under Windows)
  * [ ] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [x] Ready to review
  * [x] Ready to merge
