### PR TITLE
fix #514: fromxlsx with read_only crashes

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Version 1.6.5
+-------------
+
+* Fixed fromxlsx with read_only crashes.
+  By :user:`juarezr`, :issue:`514`.
+
+
+
 Version 1.6.4
 -------------
 

--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -61,29 +61,26 @@ class XLSXView(Table):
             wb = openpyxl.load_workbook(filename=source2,
                                         read_only=self.read_only,
                                         **self.kwargs)
-        if self.sheet is None:
-            ws = wb[wb.sheetnames[0]]
-        elif isinstance(self.sheet, int):
-            ws = wb[wb.sheetnames[self.sheet]]
-        else:
-            ws = wb[str(self.sheet)]
-
-        if self.range_string is not None:
-            rows = ws[self.range_string]
-        else:
-            rows = ws.iter_rows(min_row=self.min_row,
-                                min_col=self.min_col,
-                                max_row=self.max_row,
-                                max_col=self.max_col)
-
-        for row in rows:
-            yield tuple(cell.value for cell in row)
-
-        try:
-            wb._archive.close()
-        except AttributeError:
-            # just here in case openpyxl stops exposing an _archive property.
-            pass
+            if self.sheet is None:
+                ws = wb[wb.sheetnames[0]]
+            elif isinstance(self.sheet, int):
+                ws = wb[wb.sheetnames[self.sheet]]
+            else:
+                ws = wb[str(self.sheet)]
+            if self.range_string is not None:
+                rows = ws[self.range_string]
+            else:
+                rows = ws.iter_rows(min_row=self.min_row,
+                                    min_col=self.min_col,
+                                    max_row=self.max_row,
+                                    max_col=self.max_col)
+            for row in rows:
+                yield tuple(cell.value for cell in row)
+            try:
+                wb._archive.close()
+            except AttributeError:
+                # just here in case openpyxl stops exposing an _archive property.
+                pass
 
 
 def toxlsx(tbl, filename, sheet=None, write_header=True, mode="replace"):
@@ -174,21 +171,21 @@ def appendxlsx(tbl, filename, sheet=None, write_header=False):
     source = read_source_from_arg(filename)
     with source.open('rb') as source2:
         wb = openpyxl.load_workbook(filename=source2, read_only=False)
-    if sheet is None:
-        ws = wb[wb.sheetnames[0]]
-    elif isinstance(sheet, int):
-        ws = wb[wb.sheetnames[sheet]]
-    else:
-        ws = wb[str(sheet)]
-    if write_header:
-        rows = tbl
-    else:
-        rows = data(tbl)
-    for row in rows:
-        ws.append(row)
-    target = write_source_from_arg(filename)
-    with target.open('wb') as target2:
-        wb.save(target2)
+        if sheet is None:
+            ws = wb[wb.sheetnames[0]]
+        elif isinstance(sheet, int):
+            ws = wb[wb.sheetnames[sheet]]
+        else:
+            ws = wb[str(sheet)]
+        if write_header:
+            rows = tbl
+        else:
+            rows = data(tbl)
+        for row in rows:
+            ws.append(row)
+        target = write_source_from_arg(filename)
+        with target.open('wb') as target2:
+            wb.save(target2)
 
 
 Table.appendxlsx = appendxlsx

--- a/petl/test/io/test_xlsx.py
+++ b/petl/test/io/test_xlsx.py
@@ -33,6 +33,19 @@ else:
         ieq(expect, tbl)
         ieq(expect, tbl)
 
+    def test_fromxlsx_read_only():
+        filename = pkg_resources.resource_filename(
+            'petl', 'test/resources/test.xlsx'
+        )
+        tbl = fromxlsx(filename, sheet='Sheet1', read_only=True)
+        expect = (('foo', 'bar'),
+                  ('A', 1),
+                  ('B', 2),
+                  ('C', 2),
+                  (u'é', datetime(2012, 1, 1)))
+        ieq(expect, tbl)
+        ieq(expect, tbl)
+
     def test_fromxlsx_nosheet():
         filename = pkg_resources.resource_filename(
             'petl', 'test/resources/test.xlsx'


### PR DESCRIPTION
This PR fixes a problem reported on #514 

## Changes

1. Added test for fromxlsx(read_only=True)
2. Fixed a bug in fromxlsx with read_only=True

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [x] Code
  * [x] Includes unit tests
  * [ ] ~~New functions have docstrings with examples that can be run with doctest~~
  * [ ] ~~New functions are included in API docs~~
  * [ ] ~~Docstrings include notes for any changes to API or behaviour~~
  * [ ] All changes documented in docs/changes.rst
* [x] Testing
  * [ ] ~~\(Optional) Tested local against remote servers~~
  * [ ] Travis CI passes (unit tests run under Linux)
  * [ ] AppVeyor CI passes (unit tests run under Windows)
  * [ ] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [x] Ready to review
  * [x] Ready to merge
