### PR TITLE
fix #484: compatibility with python3.8 in petl.timings.clock()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,12 +1,18 @@
 Changes
 =======
 
+Version 1.6.6
+-------------
+
+* fix compatibility with python3.8 in `petl.timings.clock()`.
+  By :user:`juarezr`, :issue:`484`.
+
+
 Version 1.6.5
 -------------
 
 * Fixed fromxlsx with read_only crashes.
   By :user:`juarezr`, :issue:`514`.
-
 
 
 Version 1.6.4

--- a/petl/util/timing.py
+++ b/petl/util/timing.py
@@ -7,6 +7,7 @@ import sys
 import time
 
 
+from petl.compat import PY3
 from petl.util.base import Table
 from petl.util.statistics import onlinestats
 
@@ -246,11 +247,11 @@ class ClockView(Table):
         self.time = 0
         it = iter(self.wrapped)
         while True:
-            before = time.clock()
+            before = time.perf_counter() if PY3 else time.clock()
             try:
                 row = next(it)
             except StopIteration:
                 return
-            after = time.clock()
+            after = time.perf_counter() if PY3 else time.clock()
             self.time += (after - before)
             yield row


### PR DESCRIPTION
This PR has the objective of fix #484 

## Changes

1. Fixed a compatibility issue with python3.8 in `petl.timings.clock()`

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [x] Code
  * [X] Includes unit tests
  * [x] All changes documented in docs/changes.rst
* [x] Testing
  * [ ] ~~\(Optional) Tested local against remote servers~~
  * [x] Travis CI passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [x] Ready to review
  * [x] Ready to merge
