### PR TITLE
Added py38 and py39 to tox.ini for newer distros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
   - python: 2.7
   - python: 3.6
   - python: 3.7
+  - python: 3.8
     dist: xenial
     sudo: false
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,9 @@ environment:
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
 
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8"
+
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Changes
 Version 1.6.6
 -------------
 
+* Added python version 3.8 and 3.9 to tox.ini for using in newer distros.
+  By :user:`juarezr`, :issue:`517`.
+
 * fix compatibility with python3.8 in `petl.timings.clock()`.
   By :user:`juarezr`, :issue:`484`.
 

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -18,6 +18,6 @@ fsspec>=0.7.4 ; python_version >= '3.4'
 aiohttp>=3.6.2 ; python_version >= '3.5.3'
 s3fs>=0.2.2 ; python_version >= '3.4'
 # packages bellow need complex local setup
-psycopg2==2.8.3
-bcolz==1.2.1
-tables==3.5.2
+psycopg2<=2.8.6,>=2.8.3
+bcolz<=1.16.4,>=1.2.1
+tables<=3.6.1,>=3.5.2

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,10 +1,10 @@
-Cython==0.29.13
-numpy==1.16.4
-numexpr==2.6.9
+Cython<0.29.21,>=0.29.13
+numpy<=1.19.2,>=1.16.4
+numexpr<=2.7.1,>=2.6.9
 intervaltree==3.0.2
 lxml==4.4.0
 openpyxl==2.6.2
-pandas==0.24.2
+pandas<=1.1.2,>=0.24.2 ; python_version < '3.9'
 PyMySQL==0.9.3
 SQLAlchemy==1.3.6
 Whoosh==2.7.4

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
                  'Programming Language :: Python :: 3',
                  'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.7',
+                 'Programming Language :: Python :: 3.8',
                  'Topic :: Software Development :: Libraries :: Python Modules'
                  ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,9 @@ commands =
     py37: nosetests -v --with-coverage --cover-package=petl --with-doctest --doctest-options=+NORMALIZE_WHITESPACE petl -I"csv_py2\.py" -I"db\.py"
     coverage report -m
 deps =
-    :preinstall1: Cython==0.29.13
-    :preinstall1: numpy==1.16.4
-    :preinstall2: numexpr==2.6.9
+    :preinstall1: Cython<=0.29.21,>=0.29.13
+    :preinstall1: numpy<=1.19.2,>=1.16.4
+    :preinstall2: numexpr<=2.7.1,>=2.6.9
     -rtest_requirements.txt
     -roptional_requirements.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37, py37-docs
+envlist = py27, py36, py37, py38, py39, {py37,py38,py39}-docs
 # trick to enable pre-installation of numpy and numexpr
 indexserver =
     preinstall1 = https://pypi.org/simple
@@ -15,9 +15,9 @@ indexserver =
 setenv =
     PYTHONHASHSEED = 42
     py27: PY_MAJOR_VERSION = py2
-    py36,py37: PY_MAJOR_VERSION = py3
+    py36,py37,py38,py39: PY_MAJOR_VERSION = py3
 commands =
-    py27,py36: nosetests -v petl --with-coverage --cover-package=petl
+    py27,py36,py38,py39: nosetests -v petl --with-coverage --cover-package=petl
     py37: nosetests -v --with-coverage --cover-package=petl --with-doctest --doctest-options=+NORMALIZE_WHITESPACE petl -I"csv_py2\.py" -I"db\.py"
     coverage report -m
 deps =
@@ -27,7 +27,7 @@ deps =
     -rtest_requirements.txt
     -roptional_requirements.txt
 
-[testenv:py37-docs]
+[testenv:{py37,py38,py39}-docs]
 # build documentation under similar environment to readthedocs
 changedir = docs
 deps =


### PR DESCRIPTION
This PR has the objective of building `petl` with python3.8 and python3.9

## Changes

1. Added new environments `py38` and `py39` to tox.ini.
2. Build with py38 in linux on travis-ci
3. Build with py38 in windows on appveyor

## Limitations

- Package `pandas` doens't build with py39 yet.
- Packages numpy==1.19.2 and Cython==0.29.21 fails to build with py39.
- Can `py39` fix with:
  - Cython<0.29.21,>=0.29.13
  - numpy<=1.19.2,>=1.16.4
  - numexpr<=2.7.1,>=2.6.9
  - pandas<=1.1.2,>=0.24.2 ; python_version < '3.9'

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [x] Code
  * [ ] ~~Includes unit tests~~
  * [ ] ~~New functions have docstrings with examples that can be run with doctest~~
  * [ ] ~~New functions are included in API docs~~
  * [ ] ~~Docstrings include notes for any changes to API or behaviour~~
  * [x] All changes documented in docs/changes.rst
* [x] Testing
  * [ ] \(Optional) Tested local against remote servers
  * [x] Travis CI passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [x] \(Optional) Work in progress
  * [x] Ready to review
  * [x] Ready to merge
