### PR TITLE
Added new parameter parser in fromxml() for custom parsers

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+Version 1.6.8
+-------------
+
+* Allow using a custom/restricted xml parser in `fromxml()`.
+  By :user:`juarezr`, :issue:`527`.
+
+
 Version 1.6.7
 -------------
 

--- a/petl/io/xml.py
+++ b/petl/io/xml.py
@@ -133,8 +133,11 @@ def fromxml(source, *args, **kwargs):
     or list of paths can be provided, e.g.,
     ``fromxml('example.html', './/tr', ('th', 'td'))``.
 
-    Optionally a custom parser can be provided, e.g.,
-    ``etl.fromxml('example1.xml', 'tr', 'td', parser=my_parser)``.
+    Optionally a custom parser can be provided, e.g.::
+
+        >>> from lxml import etree # doctest: +SKIP
+        ... my_parser = etree.XMLParser(resolve_entities=False) # doctest: +SKIP
+        ... table4 = etl.fromxml('example1.xml', 'tr', 'td', parser=my_parser) # doctest: +SKIP
 
     """
 

--- a/petl/test/io/test_xml.py
+++ b/petl/test/io/test_xml.py
@@ -9,7 +9,8 @@ import sys
 from petl.test.helpers import ieq
 from petl.util import nrows, look
 from petl.io.xml import fromxml
-from petl.compat import urlopen
+from petl.compat import urlopen, izip_longest
+from nose.tools import eq_
 
 
 def test_fromxml():
@@ -206,3 +207,122 @@ def test_fromxml_url():
         assert nrows(actual) > 0
         expect = fromxml('.pydevproject', 'pydev_property', {'name': ( '.', 'name'), 'prop': '.'})
         ieq(expect, actual)
+
+
+def _write_temp_file(data):
+    with NamedTemporaryFile(delete=False, mode='wt') as f:
+        f.write(data)
+        res = f.name
+        f.close()
+    # txt = open(res, 'r').read()
+    # print('TEST %s:\n%s' % (res, txt), file=sys.stderr)
+    return res
+
+
+def _write_test_file(data, pre='', pos=''):
+    content = pre + '<table>' + data + pos + '</table>'
+    return _write_temp_file(content)
+
+
+def _compare(expected, actual):
+    try:
+        _eq_rows(expected, actual)
+    except Exception as ex:
+        print('Expected:\n', look(expected), file=sys.stderr)
+        print('  Actual:\n', look(actual), file=sys.stderr)
+        raise ex
+
+
+def _eq_rows(expect, actual, cast=None):
+    '''test when values are equals for eacfh row and column'''
+    ie = iter(expect)
+    ia = iter(actual)
+    for re, ra in izip_longest(ie, ia, fillvalue=None):
+        if cast:
+            ra = cast(ra)
+        for ve, va in izip_longest(re, ra, fillvalue=None):
+            if isinstance(ve, list):
+                for je, ja in izip_longest(ve, va, fillvalue=None):
+                    _eq2(je, ja, re, ra)
+            elif not isinstance(ve, dict):
+                _eq2(ve, va, re, ra)
+
+
+def _eq2(ve, va, re, ra):
+    try:
+        eq_(ve, va)
+    except AssertionError as ea:
+        print('\nrow: ', re, ' != ', ra)
+        print('val: ', ve, ' != ', va)
+        raise ea
+
+
+def test_fromxml_entity():
+    _DATA1 = """
+        <tr><td>foo</td><td>bar</td></tr>
+        <tr><td>a</td><td>1</td></tr>
+        <tr><td>b</td><td>2</td></tr>
+        <tr><td>c</td><td>3</td></tr>
+        """
+
+    _DATA2 = '<td>X</td><td>9</td>'
+
+    _DOCTYPE = """<?xml version="1.0" encoding="ISO-8859-1"?>
+    <!DOCTYPE foo [  
+        <!ELEMENT table ANY >
+        <!ENTITY inserted SYSTEM "file://%s" >]>
+        """
+
+    _INSERTED = '<tr>&inserted;</tr>'
+
+    _TABLE1 = (('foo', 'bar'),
+            ('a', '1'),
+            ('b', '2'),
+            ('c', '3'))
+
+    _EXPECT_IT = (('X', '9'),)
+
+    _EXPECT_NO = ((None, None),)
+
+    from lxml import etree
+    parser_off = etree.XMLParser(resolve_entities=False)
+    parser_onn = etree.XMLParser(resolve_entities=True)
+
+    data_file_tmp = _write_temp_file(_DATA2)
+    doc_type_temp = _DOCTYPE % data_file_tmp
+    doc_type_miss = _DOCTYPE % '/tmp/doesnotexist'
+
+    temp_file1 = _write_test_file(_DATA1)
+    temp_file2 = _write_test_file(_DATA1, pre=doc_type_temp, pos=_INSERTED)
+    temp_file3 = _write_test_file(_DATA1, pre=doc_type_miss, pos=_INSERTED)
+
+    actual11 = fromxml(temp_file1, 'tr', 'td')
+    _compare(_TABLE1, actual11)
+
+    actual12 = fromxml(temp_file1, 'tr', 'td', parser=parser_off)
+    _compare(_TABLE1, actual12)
+
+    actual21 = fromxml(temp_file2, 'tr', 'td')
+    _compare(_TABLE1 + _EXPECT_NO, actual21)
+
+    actual22 = fromxml(temp_file2, 'tr', 'td', parser=parser_off)
+    _compare(_TABLE1 + _EXPECT_NO, actual22)
+
+    actual23 = fromxml(temp_file2, 'tr', 'td', parser=parser_onn)
+    _compare(_TABLE1 + _EXPECT_IT, actual23)
+
+    actual31 = fromxml(temp_file3, 'tr', 'td')
+    _compare(_TABLE1 + _EXPECT_NO, actual31)
+
+    actual32 = fromxml(temp_file3, 'tr', 'td', parser=parser_off)
+    _compare(_TABLE1 + _EXPECT_NO, actual32)
+
+    try:
+        actual33 = fromxml(temp_file3, 'tr', 'td', parser=parser_onn)
+        for _ in actual33:
+            pass
+    except etree.XMLSyntaxError:
+        # print('XMLSyntaxError', ex, file=sys.stderr)
+        pass
+    else:
+        assert True, 'Error testing XML'

--- a/petl/test/io/test_xml.py
+++ b/petl/test/io/test_xml.py
@@ -276,59 +276,57 @@ def test_fromxml_entity():
     _INSERTED = '<tr>&inserted;</tr>'
 
     _TABLE1 = (('foo', 'bar'),
-            ('a', '1'),
-            ('b', '2'),
-            ('c', '3'))
+               ('a', '1'),
+               ('b', '2'),
+               ('c', '3'))
 
-    _EXPECT_IT = (('X', '9'),)
+    temp_file1 = _write_test_file(_DATA1)
 
-    _EXPECT_NO = ((None, None),)
+    actual11 = fromxml(temp_file1, 'tr', 'td')
+    _compare(_TABLE1, actual11)
 
     try:
         from lxml import etree
-        parser_off = etree.XMLParser(resolve_entities=False)
-        parser_onn = etree.XMLParser(resolve_entities=True)
-        found_lxml = True
     except:
-        found_lxml = False
+        return
 
     data_file_tmp = _write_temp_file(_DATA2)
     doc_type_temp = _DOCTYPE % data_file_tmp
     doc_type_miss = _DOCTYPE % '/tmp/doesnotexist'
 
-    temp_file1 = _write_test_file(_DATA1)
+    _EXPECT_IT = (('X', '9'),)
+    _EXPECT_NO = ((None, None),)
+
     temp_file2 = _write_test_file(_DATA1, pre=doc_type_temp, pos=_INSERTED)
     temp_file3 = _write_test_file(_DATA1, pre=doc_type_miss, pos=_INSERTED)
 
-    actual11 = fromxml(temp_file1, 'tr', 'td')
-    _compare(_TABLE1, actual11)
+    parser_off = etree.XMLParser(resolve_entities=False)
+    parser_onn = etree.XMLParser(resolve_entities=True)
 
-    if found_lxml:
-        actual12 = fromxml(temp_file1, 'tr', 'td', parser=parser_off)
-        _compare(_TABLE1, actual12)
+    actual12 = fromxml(temp_file1, 'tr', 'td', parser=parser_off)
+    _compare(_TABLE1, actual12)
 
     actual21 = fromxml(temp_file2, 'tr', 'td')
     _compare(_TABLE1 + _EXPECT_NO, actual21)
 
-    if found_lxml:
-        actual22 = fromxml(temp_file2, 'tr', 'td', parser=parser_off)
-        _compare(_TABLE1 + _EXPECT_NO, actual22)
+    actual22 = fromxml(temp_file2, 'tr', 'td', parser=parser_off)
+    _compare(_TABLE1 + _EXPECT_NO, actual22)
 
-        actual23 = fromxml(temp_file2, 'tr', 'td', parser=parser_onn)
-        _compare(_TABLE1 + _EXPECT_IT, actual23)
+    actual23 = fromxml(temp_file2, 'tr', 'td', parser=parser_onn)
+    _compare(_TABLE1 + _EXPECT_IT, actual23)
 
     actual31 = fromxml(temp_file3, 'tr', 'td')
     _compare(_TABLE1 + _EXPECT_NO, actual31)
 
-    if found_lxml:
-        actual32 = fromxml(temp_file3, 'tr', 'td', parser=parser_off)
-        _compare(_TABLE1 + _EXPECT_NO, actual32)
-        try:
-            actual33 = fromxml(temp_file3, 'tr', 'td', parser=parser_onn)
-            for _ in actual33:
-                pass
-        except etree.XMLSyntaxError:
-            # print('XMLSyntaxError', ex, file=sys.stderr)
+    actual32 = fromxml(temp_file3, 'tr', 'td', parser=parser_off)
+    _compare(_TABLE1 + _EXPECT_NO, actual32)
+
+    try:
+        actual33 = fromxml(temp_file3, 'tr', 'td', parser=parser_onn)
+        for _ in actual33:
             pass
-        else:
-            assert True, 'Error testing XML'
+    except etree.XMLSyntaxError:
+        # print('XMLSyntaxError', ex, file=sys.stderr)
+        pass
+    else:
+        assert True, 'Error testing XML'

--- a/petl/test/io/test_xml.py
+++ b/petl/test/io/test_xml.py
@@ -17,19 +17,19 @@ def test_fromxml():
     # initial data
     f = NamedTemporaryFile(delete=False, mode='wt')
     data = """<table>
-    <tr>
-        <td>foo</td><td>bar</td>
-    </tr>
-    <tr>
-        <td>a</td><td>1</td>
-    </tr>
-    <tr>
-        <td>b</td><td>2</td>
-    </tr>
-    <tr>
-        <td>c</td><td>2</td>
-    </tr>
-</table>"""
+        <tr>
+            <td>foo</td><td>bar</td>
+        </tr>
+        <tr>
+            <td>a</td><td>1</td>
+        </tr>
+        <tr>
+            <td>b</td><td>2</td>
+        </tr>
+        <tr>
+            <td>c</td><td>2</td>
+        </tr>
+      </table>"""
     f.write(data)
     f.close()
 
@@ -47,19 +47,19 @@ def test_fromxml_2():
     # initial data
     f = NamedTemporaryFile(delete=False, mode='wt')
     data = """<table>
-    <tr>
-        <td v='foo'/><td v='bar'/>
-    </tr>
-    <tr>
-        <td v='a'/><td v='1'/>
-    </tr>
-    <tr>
-        <td v='b'/><td v='2'/>
-    </tr>
-    <tr>
-        <td v='c'/><td v='2'/>
-    </tr>
-</table>"""
+        <tr>
+            <td v='foo'/><td v='bar'/>
+        </tr>
+        <tr>
+            <td v='a'/><td v='1'/>
+        </tr>
+        <tr>
+            <td v='b'/><td v='2'/>
+        </tr>
+        <tr>
+            <td v='c'/><td v='2'/>
+        </tr>
+      </table>"""
     f.write(data)
     f.close()
 
@@ -77,16 +77,16 @@ def test_fromxml_3():
     # initial data
     f = NamedTemporaryFile(delete=False, mode='wt')
     data = """<table>
-    <row>
-        <foo>a</foo><baz><bar v='1'/></baz>
-    </row>
-    <row>
-        <foo>b</foo><baz><bar v='2'/></baz>
-    </row>
-    <row>
-        <foo>c</foo><baz><bar v='2'/></baz>
-    </row>
-</table>"""
+        <row>
+            <foo>a</foo><baz><bar v='1'/></baz>
+        </row>
+        <row>
+            <foo>b</foo><baz><bar v='2'/></baz>
+        </row>
+        <row>
+            <foo>c</foo><baz><bar v='2'/></baz>
+        </row>
+      </table>"""
     f.write(data)
     f.close()
 
@@ -105,16 +105,16 @@ def test_fromxml_4():
     # initial data
     f = NamedTemporaryFile(delete=False, mode='wt')
     data = """<table>
-    <row>
-        <foo>a</foo><baz><bar>1</bar><bar>3</bar></baz>
-    </row>
-    <row>
-        <foo>b</foo><baz><bar>2</bar></baz>
-    </row>
-    <row>
-        <foo>c</foo><baz><bar>2</bar></baz>
-    </row>
-</table>"""
+        <row>
+            <foo>a</foo><baz><bar>1</bar><bar>3</bar></baz>
+        </row>
+        <row>
+            <foo>b</foo><baz><bar>2</bar></baz>
+        </row>
+        <row>
+            <foo>c</foo><baz><bar>2</bar></baz>
+        </row>
+      </table>"""
     f.write(data)
     f.close()
 
@@ -133,16 +133,16 @@ def test_fromxml_5():
     # initial data
     f = NamedTemporaryFile(delete=False, mode='wt')
     data = """<table>
-    <row>
-        <foo>a</foo><baz><bar v='1'/><bar v='3'/></baz>
-    </row>
-    <row>
-        <foo>b</foo><baz><bar v='2'/></baz>
-    </row>
-    <row>
-        <foo>c</foo><baz><bar v='2'/></baz>
-    </row>
-</table>"""
+        <row>
+            <foo>a</foo><baz><bar v='1'/><bar v='3'/></baz>
+        </row>
+        <row>
+            <foo>b</foo><baz><bar v='2'/></baz>
+        </row>
+        <row>
+            <foo>c</foo><baz><bar v='2'/></baz>
+        </row>
+      </table>"""
     f.write(data)
     f.close()
 
@@ -159,27 +159,27 @@ def test_fromxml_5():
 def test_fromxml_6():
 
     data = """<table class='petl'>
-<thead>
-<tr>
-<th>foo</th>
-<th>bar</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>a</td>
-<td style='text-align: right'>2</td>
-</tr>
-<tr>
-<td>b</td>
-<td style='text-align: right'>1</td>
-</tr>
-<tr>
-<td>c</td>
-<td style='text-align: right'>3</td>
-</tr>
-</tbody>
-</table>"""
+        <thead>
+        <tr>
+        <th>foo</th>
+        <th>bar</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+        <td>a</td>
+        <td style='text-align: right'>2</td>
+        </tr>
+        <tr>
+        <td>b</td>
+        <td style='text-align: right'>1</td>
+        </tr>
+        <tr>
+        <td>c</td>
+        <td style='text-align: right'>3</td>
+        </tr>
+        </tbody>
+      </table>"""
     f = NamedTemporaryFile(delete=False, mode='wt')
     f.write(data)
     f.close()
@@ -194,15 +194,15 @@ def test_fromxml_6():
     ieq(expect, actual)  # verify can iterate twice
 
 
-url = 'http://feeds.bbci.co.uk/news/rss.xml'
-# check internet connection
-try:
-    urlopen(url)
-except Exception as e:
-    print('SKIP test_fromxml_url: %s' % e, file=sys.stderr)
-else:
-
-    def test_fromxml_url():
-
-            tbl = fromxml(url, './/item', 'title')
-            assert nrows(tbl) > 0
+def test_fromxml_url():
+    # check internet connection
+    try:
+        url = 'http://raw.githubusercontent.com/petl-developers/petl/master/.pydevproject'
+        urlopen(url)
+    except Exception as e:
+        print('SKIP test_fromxml_url: %s' % e, file=sys.stderr)
+    else:
+        actual = fromxml(url, 'pydev_property', {'name': ( '.', 'name'), 'prop': '.'})
+        assert nrows(actual) > 0
+        expect = fromxml('.pydevproject', 'pydev_property', {'name': ( '.', 'name'), 'prop': '.'})
+        ieq(expect, actual)

--- a/petl/test/io/test_xml.py
+++ b/petl/test/io/test_xml.py
@@ -284,9 +284,13 @@ def test_fromxml_entity():
 
     _EXPECT_NO = ((None, None),)
 
-    from lxml import etree
-    parser_off = etree.XMLParser(resolve_entities=False)
-    parser_onn = etree.XMLParser(resolve_entities=True)
+    try:
+        from lxml import etree
+        parser_off = etree.XMLParser(resolve_entities=False)
+        parser_onn = etree.XMLParser(resolve_entities=True)
+        found_lxml = True
+    except:
+        found_lxml = False
 
     data_file_tmp = _write_temp_file(_DATA2)
     doc_type_temp = _DOCTYPE % data_file_tmp
@@ -299,30 +303,32 @@ def test_fromxml_entity():
     actual11 = fromxml(temp_file1, 'tr', 'td')
     _compare(_TABLE1, actual11)
 
-    actual12 = fromxml(temp_file1, 'tr', 'td', parser=parser_off)
-    _compare(_TABLE1, actual12)
+    if found_lxml:
+        actual12 = fromxml(temp_file1, 'tr', 'td', parser=parser_off)
+        _compare(_TABLE1, actual12)
 
     actual21 = fromxml(temp_file2, 'tr', 'td')
     _compare(_TABLE1 + _EXPECT_NO, actual21)
 
-    actual22 = fromxml(temp_file2, 'tr', 'td', parser=parser_off)
-    _compare(_TABLE1 + _EXPECT_NO, actual22)
+    if found_lxml:
+        actual22 = fromxml(temp_file2, 'tr', 'td', parser=parser_off)
+        _compare(_TABLE1 + _EXPECT_NO, actual22)
 
-    actual23 = fromxml(temp_file2, 'tr', 'td', parser=parser_onn)
-    _compare(_TABLE1 + _EXPECT_IT, actual23)
+        actual23 = fromxml(temp_file2, 'tr', 'td', parser=parser_onn)
+        _compare(_TABLE1 + _EXPECT_IT, actual23)
 
     actual31 = fromxml(temp_file3, 'tr', 'td')
     _compare(_TABLE1 + _EXPECT_NO, actual31)
 
-    actual32 = fromxml(temp_file3, 'tr', 'td', parser=parser_off)
-    _compare(_TABLE1 + _EXPECT_NO, actual32)
-
-    try:
-        actual33 = fromxml(temp_file3, 'tr', 'td', parser=parser_onn)
-        for _ in actual33:
+    if found_lxml:
+        actual32 = fromxml(temp_file3, 'tr', 'td', parser=parser_off)
+        _compare(_TABLE1 + _EXPECT_NO, actual32)
+        try:
+            actual33 = fromxml(temp_file3, 'tr', 'td', parser=parser_onn)
+            for _ in actual33:
+                pass
+        except etree.XMLSyntaxError:
+            # print('XMLSyntaxError', ex, file=sys.stderr)
             pass
-    except etree.XMLSyntaxError:
-        # print('XMLSyntaxError', ex, file=sys.stderr)
-        pass
-    else:
-        assert True, 'Error testing XML'
+        else:
+            assert True, 'Error testing XML'


### PR DESCRIPTION
This PR has the objective of restricting use of includes in `fromxml()`.

## Changes

1. Added new parameter `parser` for `fromxml()` for custom parsers.
2. Disabled file includes by default in `fromxml()`
3. Added tests for file inclusion on `fromxml()`
4. Improved the docs about `fromxml()` new parameter.

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [x] Code
  * [x] Includes unit tests
  * [x] New functions have docstrings with examples that can be run with doctest
  * [x] New functions are included in API docs
  * [x] Docstrings include notes for any changes to API or behaviour
  * [x] All changes documented in docs/changes.rst
* [x] Testing
  * [x] \(Optional) Tested local against remote servers
  * [x] Travis CI passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [x] Ready to review
  * [x] Ready to merge
