### PR TITLE
Document behavior of multi-field convert-with-row

### DIFF
--- a/petl/transform/conversions.py
+++ b/petl/transform/conversions.py
@@ -166,6 +166,25 @@ def convert(table, *args, **kwargs):
     arguments to the conversion function (so, i.e., the conversion function
     should accept two arguments).
 
+    When multiple fields are converted in a single call, the conversions
+    are independent of each other. Each conversion sees the original row::
+
+        >>> # multiple conversions do not affect each other
+        ... table13 = etl.convert(table1, {
+        ...                           "foo": lambda foo, row: row.bar,
+        ...                           "bar": lambda bar, row: row.foo,
+        ...                       }, pass_row=True)
+        >>> table13
+        +-------+-----+-----+
+        | foo   | bar | baz |
+        +=======+=====+=====+
+        | '2.4' | 'A' |  12 |
+        +-------+-----+-----+
+        | '5.7' | 'B' |  34 |
+        +-------+-----+-----+
+        | '1.2' | 'C' |  56 |
+        +-------+-----+-----+
+
     Also accepts `failonerror` and `errorvalue` keyword arguments,
     documented under :func:`petl.config.failonerror`
 


### PR DESCRIPTION
Fixes #531.

This PR has the objective of... setting in stone the fact that convert() works the way it does by design, not accident.

## Changes

1. Improved the docs about... petl.transform.conversions.convert() when used with multiple conversions in its whole-row mode.

Adds a doctest. doctests pass; I cannot get the whole test setup working at all, let alone actually test anything.

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [ ] Code
  * [ ] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [x] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes documented in docs/changes.rst
* [ ] Testing
  * [ ] \(Optional) Tested local against remote servers
  * [x] Travis CI passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [X] Changes
  * [ ] \(Optional) Just a proof of concept
  * [ ] \(Optional) Work in progress
  * [X] Ready to review
  * [ ] Ready to merge
