### PR TITLE
Fix #545 SQLAlchemy 1.4 removed/deprecated method

### DIFF
--- a/petl/io/db.py
+++ b/petl/io/db.py
@@ -183,7 +183,7 @@ def _iter_dbapi_cursor(cursor, query, *args, **kwargs):
 
 
 def _iter_sqlalchemy_engine(engine, query, *args, **kwargs):
-    return _iter_sqlalchemy_connection(engine.contextual_connect(), query,
+    return _iter_sqlalchemy_connection(engine.connect(), query,
                                        *args, **kwargs)
 
 
@@ -541,7 +541,7 @@ def _todb_dbapi_cursor(table, cursor, tablename, schema=None, commit=True,
 def _todb_sqlalchemy_engine(table, engine, tablename, schema=None, commit=True,
                             truncate=False):
 
-    _todb_sqlalchemy_connection(table, engine.contextual_connect(), tablename,
+    _todb_sqlalchemy_connection(table, engine.connect(), tablename,
                                 schema=schema, commit=commit, truncate=truncate)
 
 

--- a/petl/io/db_create.py
+++ b/petl/io/db_create.py
@@ -370,7 +370,7 @@ def _execute_sqlalchemy_connection(sql, connection, commit):
 
 
 def _execute_sqlalchemy_engine(sql, engine, commit):
-    _execute_sqlalchemy_connection(sql, engine.contextual_connect(), commit)
+    _execute_sqlalchemy_connection(sql, engine.connect(), commit)
 
 
 def _execute_sqlalchemy_session(sql, session, commit):

--- a/petl/io/db_utils.py
+++ b/petl/io/db_utils.py
@@ -22,7 +22,7 @@ def _is_dbapi_cursor(dbo):
 
 
 def _is_sqlalchemy_engine(dbo):
-    return (_hasmethods(dbo, 'execute', 'contextual_connect', 'raw_connection')
+    return (_hasmethods(dbo, 'execute', 'connect', 'raw_connection')
             and _hasprop(dbo, 'driver'))
 
 

--- a/petl/test/io/test_db_server.py
+++ b/petl/test/io/test_db_server.py
@@ -179,6 +179,14 @@ else:
         _test_dbo(sqlalchemy_session)
         sqlalchemy_session.close()
 
+        # exercise sqlalchemy engine
+        _setup_mysql(dbapi_connection)
+        sqlalchemy_engine2 = create_engine('mysql+pymysql://%s:%s@%s/%s' %
+                                           (user, password, host, database))
+        sqlalchemy_engine2.execute('SET SQL_MODE=ANSI_QUOTES')
+        _test_dbo(sqlalchemy_engine2)
+        sqlalchemy_engine2.dispose()
+
         # other exercises
         _test_with_schema(dbapi_connection, database)
         utf8_connection = connect(host=host, user=user,


### PR DESCRIPTION
This PR has the objective of fix issue with newer SQLAlchemy

## Changes

1. Fixed a bug due to SQLAlchemy 1.4 removed/deprecated method `contextual_connect()`

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [x] Code
  * [x] Includes unit tests
  * [ ] ~~New functions have docstrings with examples that can be run with doctest~~
  * [ ] ~~New functions are included in API docs~~
  * [ ] ~~Docstrings include notes for any changes to API or behaviour~~
  * [ ] All changes documented in docs/changes.rst
* [x] Testing
  * [x] Tested local against remote servers
  * [x] Travis CI passes (unit tests run under Linux)
  * [ ] AppVeyor CI passes (unit tests run under Windows)
  * [ ] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [x] Ready to review
  * [x] Ready to merge
