### PR TITLE
travis: use python 3.6 on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ branches:
   - master
   - "/v\\d+\\.\\d+\\.\\d+([abrc]+\\d)?/"
 language: python
-matrix:
+jobs:
   include:
-  - python: 2.7
   - python: 3.6
   - python: 3.7
   - python: 3.8
-    dist: xenial
-    sudo: false
+  - python: 3.9
+  - python: 2.7
+  # - python: pypy3
 before_install:
 - sudo apt-get -qq update
 - sudo apt-get build-dep -y python-h5py

--- a/requirements-formats.txt
+++ b/requirements-formats.txt
@@ -2,7 +2,7 @@ Cython<0.29.21,>=0.29.13
 numpy<=1.19.2,>=1.16.4
 numexpr<=2.7.1,>=2.6.9
 intervaltree==3.0.2
-lxml==4.6.2
+lxml==4.6.3
 openpyxl==2.6.2
 pandas<=1.1.2,>=0.24.2 ; python_version < '3.9'
 tables

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37, py38, py39, {py37,py38,py39}-docs
+envlist = py27, py36, py37, py38, py39, {py36,py37,py38}-docs
 # trick to enable pre-installation of numpy and numexpr
 indexserver =
     preinstall1 = https://pypi.org/simple
@@ -27,7 +27,7 @@ deps =
     -rrequirements-tests.txt
     -rrequirements-formats.txt
 
-[testenv:{py37,py38,py39}-docs]
+[testenv:{py36,py37,py38,py39}-docs]
 # build documentation under similar environment to readthedocs
 changedir = docs
 deps =
@@ -35,9 +35,9 @@ deps =
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
-[testenv:{py36,py37,py38,py39}-doctest]
+[testenv:{py36,py37,py38}-doctest]
 commands =
-    py36,py37,py38,py39: nosetests -v --with-doctest --doctest-options=+NORMALIZE_WHITESPACE petl -I"csv_py2\.py" -I"db\.py"
+    py36,py37,py38: nosetests -v --with-doctest --doctest-options=+NORMALIZE_WHITESPACE petl -I"csv_py2\.py" -I"db\.py"
 
 [testenv:{py36,py37,py38,py39}-dochtml]
 changedir = docs


### PR DESCRIPTION
This PR has the objective of fixing travis-ci build failure on the deploy tag.

## Changes

1. Added `python 3.9` for build on travis-ci
2. Put `python 2.7` bellow in the matrix list for avoiding failure while running `deploy` on a release tag `v#.#.#`
3. travis-ci will only trigger on main repo `github.com/petl-developers/petl`
4. Skip doctest with python3.9 for now

## Checklist

Checklist for pull requests including new code and/or changes to existing code...

* [ ] Code
  * [ ] All changes documented in docs/changes.rst
* [x] Testing
  * [x] Travis CI passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [x] Changes
  * [x] Work in progress
  * [x] Ready to review
  * [x] Ready to merge
