### PR TITLE
Fromdicts header does not raise

### DIFF
--- a/petl/io/json.py
+++ b/petl/io/json.py
@@ -163,12 +163,12 @@ class DictsView(Table):
 
     def __init__(self, dicts, header=None, sample=1000, missing=None):
         self.dicts = dicts
-        self.header = header
+        self._header = header
         self.sample = sample
         self.missing = missing
 
     def __iter__(self):
-        return iterdicts(self.dicts, self.header, self.sample, self.missing)
+        return iterdicts(self.dicts, self._header, self.sample, self.missing)
 
 
 def iterjlines(f, header, missing):

--- a/petl/test/io/test_json.py
+++ b/petl/test/io/test_json.py
@@ -177,4 +177,4 @@ def test_fromdicts_header_does_not_raise():
             {'foo': 'b', 'bar': 2},
             {'foo': 'c', 'bar': 2}]
     actual = fromdicts(data)
-    assert actual.header() == ("foo", "bar")
+    assert actual.header()

--- a/petl/test/io/test_json.py
+++ b/petl/test/io/test_json.py
@@ -170,3 +170,11 @@ def test_tojsonarrays():
     assert result[1][1] == 2
     assert result[2][0] == 'c'
     assert result[2][1] == 2
+
+
+def test_fromdicts_header_does_not_raise():
+    data = [{'foo': 'a', 'bar': 1},
+            {'foo': 'b', 'bar': 2},
+            {'foo': 'c', 'bar': 2}]
+    actual = fromdicts(data)
+    assert actual.header() == ("foo", "bar")


### PR DESCRIPTION
This PR has the objective of... being able to call header method when the table has been created with fromdicts
Originally reported here https://github.com/petl-developers/petl/issues/391

## Changes

1. Renamed internal attribute header to _header so there is no conflict with the method with the same name.

## Checklist

Checklist for pull requests including new code and/or changes to existing code...

* [x] Code
  * [x] Includes unit tests
  * [ ] All changes documented in docs/changes.rst
* [x] Testing
  * [x] Travis CI passes (unit tests run under Linux)
* [x] Changes
  * [x] Ready to review
  * [ ] Ready to merge
