### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/petl/io/sources.py
+++ b/petl/io/sources.py
@@ -459,7 +459,7 @@ def read_source_from_arg(source):
     Retrieve a open stream for reading from the source provided.
 
     The result stream will be open by a handler that would return raw bytes and
-    transparently take care of the descompression, remote authentication,
+    transparently take care of the decompression, remote authentication,
     network transfer, format decoding, and data extraction.
 
     .. versionadded:: 1.4.0

--- a/petl/test/io/test_avro.py
+++ b/petl/test/io/test_avro.py
@@ -25,7 +25,7 @@ if PY3:
 
 try:
     import fastavro
-    # import fastavro depedencies
+    # import fastavro dependencies
     import pytz
 except ImportError as e:
     print('SKIP avro tests: %s' % e, file=sys.stderr)

--- a/petl/transform/basics.py
+++ b/petl/transform/basics.py
@@ -1159,7 +1159,7 @@ def addfieldusingcontext(table, field, query):
         +-----+-----+------+------+
 
     The `field` parameter is the name of the field to be added. The `query`
-    parameter is a function operating on the curent, previous and next rows
+    parameter is a function operating on the current, previous and next rows
     and returning the value.
 
     """


### PR DESCRIPTION
There are small typos in:
- petl/io/sources.py
- petl/test/io/test_avro.py
- petl/transform/basics.py

Fixes:
- Should read `dependencies` rather than `depedencies`.
- Should read `decompression` rather than `descompression`.
- Should read `current` rather than `curent`.

Closes #557


This PR has the objective of...

## Changes

1. Added new `xyz` to...
2. Fixed a bug in...
3. Changed the behaviour of...
4. Improved the docs about...

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [ ] Code
  * [ ] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes documented in docs/changes.rst
* [ ] Testing
  * [ ] \(Optional) Tested local against remote servers
  * [ ] Travis CI passes (unit tests run under Linux)
  * [ ] AppVeyor CI passes (unit tests run under Windows)
  * [ ] Unit test coverage has not decreased (see Coveralls)
* [ ] Changes
  * [ ] \(Optional) Just a proof of concept
  * [ ] \(Optional) Work in progress
  * [ ] Ready to review
  * [ ] Ready to merge
