### PR TITLE
[POC] added typing to materialize (breaks py27 tests)

### DIFF
--- a/petl/util/materialise.py
+++ b/petl/util/materialise.py
@@ -4,13 +4,15 @@ from __future__ import absolute_import, print_function, division
 import operator
 from collections import OrderedDict
 from itertools import islice
+from typing import Dict, Tuple, List, Any
+
 from petl.compat import izip_longest, text_type, next
 
 
 from petl.util.base import asindices, Table
 
 
-def listoflists(tbl):
+def listoflists(tbl) -> List[list]:
     return [list(row) for row in tbl]
 
 
@@ -18,7 +20,7 @@ Table.listoflists = listoflists
 Table.lol = listoflists
 
 
-def tupleoftuples(tbl):
+def tupleoftuples(tbl) -> Tuple[tuple, ...]:
     return tuple(tuple(row) for row in tbl)
 
 
@@ -26,7 +28,7 @@ Table.tupleoftuples = tupleoftuples
 Table.tot = tupleoftuples
 
 
-def listoftuples(tbl):
+def listoftuples(tbl) -> List[tuple]:
     return [tuple(row) for row in tbl]
 
 
@@ -34,7 +36,7 @@ Table.listoftuples = listoftuples
 Table.lot = listoftuples
 
 
-def tupleoflists(tbl):
+def tupleoflists(tbl) -> Tuple[list, ...]:
     return tuple(list(row) for row in tbl)
 
 
@@ -42,7 +44,7 @@ Table.tupleoflists = tupleoflists
 Table.tol = tupleoflists
 
 
-def columns(table, missing=None):
+def columns(table, missing=None) -> OrderedDict:
     """
     Construct a :class:`dict` mapping field names to lists of values. E.g.::
 
@@ -74,7 +76,7 @@ def columns(table, missing=None):
 Table.columns = columns
 
 
-def facetcolumns(table, key, missing=None):
+def facetcolumns(table, key, missing=None) -> Dict[Any, Dict[str, Any]]:
     """
     Like :func:`petl.util.materialise.columns` but stratified by values of the
     given key field. E.g.::
@@ -119,7 +121,7 @@ def facetcolumns(table, key, missing=None):
 Table.facetcolumns = facetcolumns
 
 
-def cache(table, n=None):
+def cache(table, n=None) -> 'CacheView':
     """
     Wrap the table with a cache that caches up to `n` rows as they are initially
     requested via iteration (cache all rows be default).


### PR DESCRIPTION
Proof of concept: typing for petl

## Changes

1. Added typing for some functions in `materialize.py` 

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [ ] Code
  * [ ] Includes unit tests
  * [x] New functions have docstrings with examples that can be run with doctest (no new functions)
  * [x] New functions are included in API docs (no new functions)
  * [x] Docstrings include notes for any changes to API or behaviour (no changes in API behavior)
  * [ ] All changes documented in docs/changes.rst
* [ ] Testing
  * [x] \(Optional) Tested local against remote servers
  * [ ] Travis CI passes (unit tests run under Linux)
  * [ ] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [ ] Changes
  * [x] \(Optional) Just a proof of concept
  * [ ] \(Optional) Work in progress
  * [ ] Ready to review
  * [ ] Ready to merge
