### PR TITLE
Add support for generators in the petl.fromdicts. Allows to get heade…

### DIFF
--- a/petl/io/json.py
+++ b/petl/io/json.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, division
 import io
 import itertools
 import json
-import typing
+import inspect
 from json.encoder import JSONEncoder
 
 from petl.compat import PY2
@@ -157,7 +157,7 @@ def fromdicts(dicts, header=None, sample=1000, missing=None):
     guarantee stability.
 
     """
-    view = DictsGeneratorView if isinstance(dicts, typing.Generator) else DictsView
+    view = DictsGeneratorView if inspect.isgenerator(dicts) else DictsView
     return view(dicts, header=header, sample=sample, missing=missing)
 
 

--- a/petl/io/json.py
+++ b/petl/io/json.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import, print_function, division
 
 # standard library dependencies
 import io
+import itertools
 import json
+import typing
 from json.encoder import JSONEncoder
 
 from petl.compat import PY2
@@ -155,8 +157,8 @@ def fromdicts(dicts, header=None, sample=1000, missing=None):
     guarantee stability.
 
     """
-
-    return DictsView(dicts, header=header, sample=sample, missing=missing)
+    view = DictsGeneratorView if isinstance(dicts, typing.Generator) else DictsView
+    return view(dicts, header=header, sample=sample, missing=missing)
 
 
 class DictsView(Table):
@@ -169,6 +171,13 @@ class DictsView(Table):
 
     def __iter__(self):
         return iterdicts(self.dicts, self._header, self.sample, self.missing)
+
+
+class DictsGeneratorView(DictsView):
+
+    def __iter__(self):
+        self.dicts, dicts = itertools.tee(self.dicts)
+        return iterdicts(dicts, self._header, self.sample, self.missing)
 
 
 def iterjlines(f, header, missing):

--- a/petl/test/io/test_json.py
+++ b/petl/test/io/test_json.py
@@ -181,15 +181,14 @@ def test_fromdicts_header_does_not_raise():
 
 
 def test_fromdicts_header_list():
-    data = [
-        {'bar': 'a', 'foo': 1},
-        {'bar': 'b', 'foo': 2},
-        {'bar': 'c', 'foo': 2},
-    ]
+    from collections import OrderedDict
+    data = [OrderedDict([('foo', 'a'), ('bar', 1)]),
+        OrderedDict([('foo', 'b'), ('bar', 2)]),
+        OrderedDict([('foo', 'c'), ('bar', 2)])]
     actual = fromdicts(data)
     header = actual.header()
-    assert header == ('bar', 'foo')
-    expect = (('bar', 'foo'),
+    assert header == ('foo', 'bar')
+    expect = (('foo', 'bar'),
               ('a', 1),
               ('b', 2),
               ('c', 2))
@@ -198,15 +197,17 @@ def test_fromdicts_header_list():
 
 
 def test_fromdicts_header_generator():
+    from collections import OrderedDict
+
     def generator():
-        yield {'bar': 'a', 'foo': 1}
-        yield {'bar': 'b', 'foo': 2}
-        yield {'bar': 'c', 'foo': 2}
+        yield OrderedDict([('foo', 'a'), ('bar', 1)])
+        yield OrderedDict([('foo', 'b'), ('bar', 2)])
+        yield OrderedDict([('foo', 'c'), ('bar', 2)])
 
     actual = fromdicts(generator())
     header = actual.header()
-    assert header == ('bar', 'foo')
-    expect = (('bar', 'foo'),
+    assert header == ('foo', 'bar')
+    expect = (('foo', 'bar'),
               ('a', 1),
               ('b', 2),
               ('c', 2))

--- a/petl/test/io/test_json.py
+++ b/petl/test/io/test_json.py
@@ -178,3 +178,37 @@ def test_fromdicts_header_does_not_raise():
             {'foo': 'c', 'bar': 2}]
     actual = fromdicts(data)
     assert actual.header()
+
+
+def test_fromdicts_header_list():
+    data = [
+        {'bar': 'a', 'foo': 1},
+        {'bar': 'b', 'foo': 2},
+        {'bar': 'c', 'foo': 2},
+    ]
+    actual = fromdicts(data)
+    header = actual.header()
+    assert header == ('bar', 'foo')
+    expect = (('bar', 'foo'),
+              ('a', 1),
+              ('b', 2),
+              ('c', 2))
+    ieq(expect, actual)
+    ieq(expect, actual)
+
+
+def test_fromdicts_header_generator():
+    def generator():
+        yield {'bar': 'a', 'foo': 1}
+        yield {'bar': 'b', 'foo': 2}
+        yield {'bar': 'c', 'foo': 2}
+
+    actual = fromdicts(generator())
+    header = actual.header()
+    assert header == ('bar', 'foo')
+    expect = (('bar', 'foo'),
+              ('a', 1),
+              ('b', 2),
+              ('c', 2))
+    ieq(expect, actual)
+    ieq(expect, actual)


### PR DESCRIPTION
…rs, and iterate over the generator multiple times


This PR has the objective of allowing to pass a generator to petl.fromdicts() and closes: https://github.com/petl-developers/petl/pull/569
## Changes

1. Added `DictsGeneratorView` supporting generators
3. Changed the behaviour of `petl.fromdicts()` to detect passing of generator

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [ ] Code
  * [x] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes documented in docs/changes.rst
* [ ] Testing
  * [x] Tested with tox with all supported python versions (including 2.7) 
  * [ ] \(Optional) Tested local against remote servers
  * [ ] Travis CI passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [ ] Unit test coverage has not decreased (see Coveralls)
* [ ] Changes
  * [x] Ready to review
  * [ ] Ready to merge
