### PR TITLE
Add support for ignore_workbook_corruption parameter in xlrd, bump xl…

### DIFF
--- a/petl/io/xls.py
+++ b/petl/io/xls.py
@@ -40,7 +40,7 @@ class XLSView(Table):
             source = read_source_from_arg(self.filename)
             with source.open('rb') as source2:
                 source3 = source2.read()
-                wb = xlutils_view.View(source3)
+                wb = xlutils_view.View(source3, **self.kwargs)
                 if self.sheet is None:
                     ws = wb[0]
                 else:

--- a/petl/test/io/test_xls.py
+++ b/petl/test/io/test_xls.py
@@ -6,6 +6,11 @@ import sys
 from datetime import datetime
 from tempfile import NamedTemporaryFile
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 import petl as etl
 from petl.io.xls import fromxls, toxls
 from petl.test.helpers import ieq
@@ -101,3 +106,25 @@ else:
         actual = etl.fromxls(f.name, 'Sheet1')
         ieq(expect, actual)
         ieq(expect, actual)
+
+    def test_passing_kwargs_to_xlutils_view():
+        filename = _get_test_xls()
+        if filename is None:
+            return
+
+        from petl.io.xlutils_view import View
+        org_init = View.__init__
+
+        def wrapper(self, *args, **kwargs):
+            assert "ignore_workbook_corruption" in kwargs
+            return org_init(self, *args, **kwargs)
+
+        with patch("petl.io.xlutils_view.View.__init__", wrapper):
+            tbl = fromxls(filename, 'Sheet1', use_view=True, ignore_workbook_corruption=True)
+            expect = (('foo', 'bar'),
+                      ('A', 1),
+                      ('B', 2),
+                      ('C', 2),
+                      (u'é', datetime(2012, 1, 1)))
+            ieq(expect, tbl)
+            ieq(expect, tbl)

--- a/requirements-formats.txt
+++ b/requirements-formats.txt
@@ -7,7 +7,7 @@ openpyxl==2.6.2
 pandas<=1.1.2,>=0.24.2 ; python_version < '3.9'
 tables
 Whoosh==2.7.4
-xlrd==1.2.0
+xlrd==2.0.1
 xlwt==1.3.0
 fastavro>=0.24.2 ; python_version >= '3.4'
 fastavro==0.24.2 ; python_version < '3.0'

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,3 +5,4 @@ tox
 coveralls
 coverage
 setuptools-scm
+mock; python_version < '3.0'


### PR DESCRIPTION
…rd version to 2.0.1. Pass kwargs to xlutils_view.View in XLSView


This PR has the objective of adding support of `ignore_workbook_corruption` option added to `xlrd` version `2.0.0
`
## Changes

1. Upgrade `xlrd` package to `2.0.1`
2. Pass kwargs passed to `fromxls` to `xlutils_view.View`
## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [ ] Code
  * [x] Includes unit tests
* [ ] Testing
  * [ ] Travis CI passes (unit tests run under Linux)
  * [ ] AppVeyor CI passes (unit tests run under Windows)
  * [ ] Unit test coverage has not decreased (see Coveralls)
* [ ] Changes
  * [x] Ready to review
  * [ ] Ready to merge
