### PR TITLE
Fix convertall() when header line contain non-string values

### DIFF
--- a/petl/test/transform/test_conversions.py
+++ b/petl/test/transform/test_conversions.py
@@ -214,6 +214,14 @@ def test_convertall():
     ieq(expect2, table2)
     ieq(expect2, table2)
 
+    # test with non-string field names
+    table1 = (('foo', 3, 4),
+              (2, 2, 2))
+    table2 = convertall(table1, lambda x: x**2)
+    expect = (('foo', 3, 4),
+              (4, 4, 4))
+    ieq(expect, table2)
+
 
 def test_convertnumbers():
 

--- a/petl/transform/conversions.py
+++ b/petl/transform/conversions.py
@@ -6,7 +6,7 @@ from petl.compat import next, integer_types, string_types, text_type
 
 import petl.config as config
 from petl.errors import ArgumentError, FieldSelectionError
-from petl.util.base import Table, expr, header, Record
+from petl.util.base import Table, expr, fieldnames, Record
 from petl.util.parsers import numparser
 
 
@@ -242,7 +242,7 @@ def convertall(table, *args, **kwargs):
     """
 
     # TODO don't read the data twice!
-    return convert(table, header(table), *args, **kwargs)
+    return convert(table, fieldnames(table), *args, **kwargs)
 
 
 Table.convertall = convertall


### PR DESCRIPTION
Fixes #579.
