### PR TITLE
Fix todataframe() to do not iterate the table multiple times

### DIFF
--- a/petl/io/pandas.py
+++ b/petl/io/pandas.py
@@ -28,11 +28,11 @@ def todataframe(table, index=None, exclude=None, columns=None,
 
     """
     import pandas as pd
-    l = list(table)
-    data = l[1:]
+    it = iter(table)
+    header = next(it)
     if columns is None:
-        columns = l[0]
-    return pd.DataFrame.from_records(data, index=index, exclude=exclude,
+        columns = header
+    return pd.DataFrame.from_records(it, index=index, exclude=exclude,
                                      columns=columns, coerce_float=coerce_float,
                                      nrows=nrows)
 


### PR DESCRIPTION
Converting the table data to a list simply with list() causes the
table to be materialized three times because list() calls __len__()
on the table twice to populate the list.

Anyhow, there is no need to have the table data in a list when an
iteratotor can be passed to pandas.DataFrame.from_records().

Fixes #578.