### PR TITLE
Migrate to pytest

### DIFF
--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Test python source code for mode ${{ env.testing }}
         if: env.testing == 'simple'
-        run: nosetests -v petl --with-coverage --cover-package=petl
+        run: pytest --cov=petl petl
 
       - name: Test documentation inside source code for mode ${{ env.testing }}
         if: env.testing == 'full'
@@ -122,7 +122,7 @@ jobs:
           python -m pip install -r requirements-formats.txt
           echo "::endgroup::"
           echo "::group::Perform doc test execution with coverage"
-          nosetests -v --with-coverage --cover-package=petl --with-doctest --doctest-options=+NORMALIZE_WHITESPACE petl -I"csv_py2\.py" -I"db\.py"
+          pytest --cov=petl petl
           echo "::endgroup::"
 
       - name: Coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,4 +33,4 @@ build: off
 test_script:
   - "%CMD_IN_ENV% python -m pip install -U pip setuptools wheel nose mock"
   - "%CMD_IN_ENV% python setup.py install"
-  - "%CMD_IN_ENV% python -m nose -v petl"
+  - "%CMD_IN_ENV% python -m pytest petl"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,6 @@ install:
 build: off
 
 test_script:
-  - "%CMD_IN_ENV% python -m pip install -U pip setuptools wheel nose mock"
+  - "%CMD_IN_ENV% python -m pip install -U pip setuptools wheel pytest mock"
   - "%CMD_IN_ENV% python setup.py install"
   - "%CMD_IN_ENV% python -m pytest petl"

--- a/petl/io/db.py
+++ b/petl/io/db.py
@@ -183,8 +183,10 @@ def _iter_dbapi_cursor(cursor, query, *args, **kwargs):
 
 
 def _iter_sqlalchemy_engine(engine, query, *args, **kwargs):
-    return _iter_sqlalchemy_connection(engine.connect(), query,
-                                       *args, **kwargs)
+    connection = engine.connect()
+    for row in _iter_sqlalchemy_connection(connection, query, *args, **kwargs):
+        yield row
+    connection.close()
 
 
 def _iter_sqlalchemy_connection(connection, query, *args, **kwargs):

--- a/petl/test/conftest.py
+++ b/petl/test/conftest.py
@@ -1,0 +1,10 @@
+import logging
+
+
+def pytest_configure():
+    org = logging.Logger.debug
+
+    def debug(self, msg, *args, **kwargs):
+        org(self, str(msg), *args, **kwargs)
+
+    logging.Logger.debug = debug

--- a/petl/test/failonerror.py
+++ b/petl/test/failonerror.py
@@ -1,11 +1,11 @@
+import pytest
+
 from petl.test.helpers import ieq, eq_
 import petl.config as config
 
-from nose.tools import nottest
 
 
-@nottest
-def test_failonerror(input_fn, expected_output):
+def assert_failonerror(input_fn, expected_output):
     """In the input rows, the first row should process through the
     transformation cleanly.  The second row should generate an
     exception.  There are no requirements for any other rows."""
@@ -33,13 +33,9 @@ def test_failonerror(input_fn, expected_output):
 
     # When called with failonerror=True, a bad conversion raises an
     # exception
-    try:
+    with pytest.raises(Exception):
         table4 = input_fn(failonerror=True)
         table4.nrows()
-    except Exception:
-        pass
-    else:
-        raise Exception('expected exception not raised')
 
     # When called with failonerror='inline', a bad conversion
     # does not raise an exception, and an Exception for the failed
@@ -60,13 +56,9 @@ def test_failonerror(input_fn, expected_output):
     # When config.failonerror == True, a bad conversion raises an
     # exception
     config.failonerror = True
-    try:
+    with pytest.raises(Exception):
         table6 = input_fn()
         table6.nrows()
-    except Exception:
-        pass
-    else:
-        raise Exception('expected exception not raised')
 
     # When config.failonerror == 'inline', a bad conversion
     # does not raise an exception, and an Exception for the failed
@@ -82,13 +74,9 @@ def test_failonerror(input_fn, expected_output):
     # When config.failonerror is an invalid value, but still truthy, it
     # behaves the same as if == True
     config.failonerror = 'invalid'
-    try:
+    with pytest.raises(Exception):
         table8 = input_fn()
         table8.nrows()
-    except Exception:
-        pass
-    else:
-        raise Exception('expected exception not raised')
 
     # When config.failonerror is None, it behaves the same as if
     # config.failonerror is False
@@ -105,13 +93,9 @@ def test_failonerror(input_fn, expected_output):
 
     # A None keyword parameter uses config.failonerror == True
     config.failonerror = True
-    try:
+    with pytest.raises(Exception):
         table11 = input_fn(failonerror=None)
         table11.nrows()
-    except Exception:
-        pass
-    else:
-        raise Exception('expected exception not raised')
 
     # restore config setting
     config.failonerror = saved_config_failonerror

--- a/petl/test/helpers.py
+++ b/petl/test/helpers.py
@@ -2,10 +2,18 @@ from __future__ import absolute_import, print_function, division
 
 import sys
 
-from nose.tools import eq_, assert_almost_equal
+import pytest
 
 from petl.compat import izip_longest
 
+
+def eq_(expect, actual, msg=None):
+    assert expect == actual, msg
+
+
+def assert_almost_equal(first, second, places=None, msg=None):
+    abs = None if places is None else 10**-places
+    assert pytest.approx(first, second, abs=abs), msg
 
 def ieq(expect, actual, cast=None):
     '''test when values are equals for eacfh row and column'''

--- a/petl/test/io/test_avro.py
+++ b/petl/test/io/test_avro.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
 
-import sys
 import math
 
 from datetime import datetime, date
 from decimal import Decimal
 from tempfile import NamedTemporaryFile
+
+import pytest
 
 from petl.compat import PY3
 from petl.transform.basics import cat
@@ -28,7 +29,7 @@ try:
     # import fastavro dependencies
     import pytz
 except ImportError as e:
-    print('SKIP avro tests: %s' % e, file=sys.stderr)
+    pytest.skip('SKIP avro tests: %s' % e, allow_module_level=True)
 else:
     # region Test Cases
 

--- a/petl/test/io/test_bcolz.py
+++ b/petl/test/io/test_bcolz.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
-import sys
 import tempfile
 
+import pytest
 
 from petl.test.helpers import ieq, eq_
 from petl.io.bcolz import frombcolz, tobcolz, appendbcolz
@@ -11,7 +11,7 @@ from petl.io.bcolz import frombcolz, tobcolz, appendbcolz
 try:
     import bcolz
 except ImportError as e:
-    print('SKIP bcolz tests: %s' % e, file=sys.stderr)
+    pytest.skip('SKIP bcolz tests: %s' % e, allow_module_level=True)
 else:
 
     def test_frombcolz():

--- a/petl/test/io/test_db_create.py
+++ b/petl/test/io/test_db_create.py
@@ -2,11 +2,11 @@
 from __future__ import absolute_import, print_function, division
 
 
-import sys
 import logging
 from datetime import datetime, date
 import sqlite3
 
+import pytest
 
 from petl.io.db import fromdb, todb
 from petl.io.db_create import make_sqlalchemy_column
@@ -98,7 +98,7 @@ try:
     # noinspection PyUnresolvedReferences
     import sqlalchemy
 except ImportError as e:
-    print('SKIP generic create tests: %s' % e, file=sys.stderr)
+    pytest.skip('SKIP generic create tests: %s' % e, allow_module_level=True)
 else:
 
     from sqlalchemy import Column, DateTime, Date
@@ -131,7 +131,7 @@ else:
         _test_create(dbapi_cursor)
         dbapi_cursor.close()
 
-
+SKIP_PYMYSQL = False
 try:
     import pymysql
     import sqlalchemy
@@ -140,9 +140,9 @@ try:
                     password=password,
                     database=database)
 except Exception as e:
-    print('SKIP pymysql create tests: %s' % e, file=sys.stderr)
-else:
-
+    SKIP_PYMYSQL = 'SKIP pymysql create tests: %s' % e
+finally:
+    @pytest.mark.skipif(SKIP_PYMYSQL, reason=SKIP_PYMYSQL)
     def test_mysql_create():
 
         import pymysql
@@ -183,6 +183,7 @@ else:
         sqlalchemy_session.close()
 
 
+SKIP_POSTGRES = False
 try:
     import psycopg2
     import sqlalchemy
@@ -191,9 +192,9 @@ try:
         % (host, database, user, password)
     )
 except Exception as e:
-    print('SKIP psycopg2 create tests: %s' % e, file=sys.stderr)
-else:
-
+    SKIP_POSTGRES = 'SKIP psycopg2 create tests: %s' % e
+finally:
+    @pytest.mark.skipif(bool(SKIP_POSTGRES), reason=str(SKIP_POSTGRES))
     def test_postgresql_create():
         import psycopg2
         import psycopg2.extensions

--- a/petl/test/io/test_db_create.py
+++ b/petl/test/io/test_db_create.py
@@ -142,7 +142,7 @@ try:
 except Exception as e:
     SKIP_PYMYSQL = 'SKIP pymysql create tests: %s' % e
 finally:
-    @pytest.mark.skipif(SKIP_PYMYSQL, reason=SKIP_PYMYSQL)
+    @pytest.mark.skipif(bool(SKIP_PYMYSQL), reason=str(SKIP_PYMYSQL))
     def test_mysql_create():
 
         import pymysql

--- a/petl/test/io/test_numpy.py
+++ b/petl/test/io/test_numpy.py
@@ -2,8 +2,7 @@
 from __future__ import absolute_import, print_function, division
 
 
-import sys
-
+import pytest
 
 import petl as etl
 from petl.test.helpers import ieq, eq_, assert_almost_equal
@@ -14,7 +13,7 @@ try:
     # noinspection PyUnresolvedReferences
     import numpy as np
 except ImportError as e:
-    print('SKIP numpy tests: %s' % e, file=sys.stderr)
+    pytest.skip('SKIP numpy tests: %s' % e, allow_module_level=True)
 else:
 
     def test_toarray_nodtype():

--- a/petl/test/io/test_pandas.py
+++ b/petl/test/io/test_pandas.py
@@ -2,8 +2,7 @@
 from __future__ import division, print_function, absolute_import
 
 
-import sys
-
+import pytest
 
 import petl as etl
 from petl.test.helpers import ieq
@@ -14,7 +13,7 @@ try:
     # noinspection PyUnresolvedReferences
     import pandas as pd
 except ImportError as e:
-    print('SKIP pandas tests: %s' % e, file=sys.stderr)
+    pytest.skip('SKIP pandas tests: %s' % e, allow_module_level=True)
 else:
 
     def test_todataframe():

--- a/petl/test/io/test_pytables.py
+++ b/petl/test/io/test_pytables.py
@@ -2,10 +2,10 @@
 from __future__ import division, print_function, absolute_import
 
 
-import sys
 from itertools import chain
 from tempfile import NamedTemporaryFile
 
+import pytest
 
 from petl.test.helpers import ieq
 from petl.transform.sorts import sort
@@ -17,7 +17,7 @@ try:
     # noinspection PyUnresolvedReferences
     import tables
 except ImportError as e:
-    print('SKIP pytables tests: %s' % e, file=sys.stderr)
+    pytest.skip('SKIP pytables tests: %s' % e, allow_module_level=True)
 else:
 
     class FooBar(tables.IsDescription):

--- a/petl/test/io/test_remotes.py
+++ b/petl/test/io/test_remotes.py
@@ -5,6 +5,8 @@ import sys
 import os
 from importlib import import_module
 
+import pytest
+
 from petl.compat import PY3
 from petl.test.helpers import ieq, eq_
 from petl.io.avro import fromavro, toavro
@@ -28,7 +30,7 @@ def test_helper_fsspec():
         # pylint: disable=unused-import
         import fsspec  # noqa: F401
     except ImportError as e:
-        print("SKIP FSSPEC helper tests: %s" % e, file=sys.stderr)
+        pytest.skip("SKIP FSSPEC helper tests: %s" % e)
     else:
         _write_read_from_env_matching("PETL_TEST_")
 
@@ -38,7 +40,7 @@ def test_helper_smb():
         # pylint: disable=unused-import
         import smbclient  # noqa: F401
     except ImportError as e:
-        print("SKIP SMB helper tests: %s" % e, file=sys.stderr)
+        pytest.skip("SKIP SMB helper tests: %s" % e)
     else:
         _write_read_from_env_url("PETL_SMB_URL")
 

--- a/petl/test/io/test_whoosh.py
+++ b/petl/test/io/test_whoosh.py
@@ -2,10 +2,10 @@
 from __future__ import absolute_import, print_function, division
 
 
-import sys
 import os
 import tempfile
 
+import pytest
 
 from petl.test.helpers import ieq
 import petl as etl
@@ -17,7 +17,7 @@ try:
     # noinspection PyUnresolvedReferences
     import whoosh
 except ImportError as e:
-    print('SKIP whoosh tests: %s' % e, file=sys.stderr)
+    pytest.skip('SKIP whoosh tests: %s' % e, allow_module_level=True)
 else:
 
     from whoosh.index import create_in

--- a/petl/test/io/test_xls.py
+++ b/petl/test/io/test_xls.py
@@ -2,9 +2,10 @@
 from __future__ import division, print_function, absolute_import
 
 
-import sys
 from datetime import datetime
 from tempfile import NamedTemporaryFile
+
+import pytest
 
 try:
     from unittest.mock import patch
@@ -30,7 +31,7 @@ try:
     # noinspection PyUnresolvedReferences
     import xlwt
 except ImportError as e:
-    print('SKIP xls tests: %s' % e, file=sys.stderr)
+    pytest.skip('SKIP xls tests: %s' % e, allow_module_level=True)
 else:
 
     def test_fromxls():

--- a/petl/test/io/test_xlsx.py
+++ b/petl/test/io/test_xlsx.py
@@ -2,9 +2,10 @@
 from __future__ import absolute_import, print_function, division
 
 
-import sys
 from datetime import datetime
 from tempfile import NamedTemporaryFile
+
+import pytest
 
 import petl as etl
 from petl.io.xlsx import fromxlsx, toxlsx, appendxlsx
@@ -23,7 +24,7 @@ try:
     # noinspection PyUnresolvedReferences
     import openpyxl
 except ImportError as e:
-    print('SKIP xlsx tests: %s' % e, file=sys.stderr)
+    pytest.skip('SKIP xlsx tests: %s' % e, allow_module_level=True)
 else:
 
     def test_fromxlsx():

--- a/petl/test/io/test_xml.py
+++ b/petl/test/io/test_xml.py
@@ -5,6 +5,8 @@ import sys
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 
+import pytest
+
 from petl.test.helpers import ieq
 from petl.util import nrows, look
 from petl.io.xml import fromxml, toxml
@@ -201,7 +203,7 @@ def test_fromxml_url():
         import pkg_resources
         filename = pkg_resources.resource_filename('petl', 'test/resources/test.xml')
     except Exception as e:
-        print('SKIP test_fromxml_url: %s' % e, file=sys.stderr)
+        pytest.skip('SKIP test_fromxml_url: %s' % e)
     else:
         actual = fromxml(url, 'pydev_property', {'name': ( '.', 'name'), 'prop': '.'})
         assert nrows(actual) > 0

--- a/petl/test/transform/test_conversions.py
+++ b/petl/test/transform/test_conversions.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, division
 
 
-from petl.test.failonerror import test_failonerror
+from petl.test.failonerror import assert_failonerror
 from petl.test.helpers import ieq
 from petl.transform.conversions import convert, convertall, convertnumbers, \
     replace, update, format, interpolate
@@ -305,7 +305,7 @@ def test_convert_failonerror():
     cvt_    = {'foo': 'lower'}
     expect_ = (('foo',), ('a',), (None,))
 
-    test_failonerror(
+    assert_failonerror(
             input_fn=partial(convert, input_, cvt_),
             expected_output=expect_)
 

--- a/petl/test/transform/test_intervals.py
+++ b/petl/test/transform/test_intervals.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, print_function, division
 
 
 import logging
-import sys
 
+import pytest
 
 import petl as etl
 from petl.test.helpers import ieq, eq_
@@ -23,7 +23,7 @@ try:
     # noinspection PyUnresolvedReferences
     import intervaltree
 except ImportError as e:
-    print('SKIP interval tests: %s' % e, file=sys.stderr)
+    pytest.skip('SKIP interval tests: %s' % e, allow_module_level=True)
 else:
 
     def test_intervallookup():

--- a/petl/test/transform/test_maps.py
+++ b/petl/test/transform/test_maps.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 from collections import OrderedDict
 
-from petl.test.failonerror import test_failonerror
+from petl.test.failonerror import assert_failonerror
 from petl.test.helpers import ieq
 from petl.transform.maps import fieldmap, rowmap, rowmapmany
 
@@ -96,7 +96,7 @@ def test_fieldmap_failonerror():
     mapper_ = {'bar': ('foo', lambda v: v.lower())}
     expect_ = (('bar',), ('a',), (None,))
 
-    test_failonerror(
+    assert_failonerror(
             input_fn=partial(fieldmap, input_, mapper_),
             expected_output=expect_)
 
@@ -166,7 +166,7 @@ def test_rowmap_failonerror():
     # exceptions in rowmappers do not generate an output row
     expect_ = (('foo',), ('a',), ('b',))
 
-    test_failonerror(
+    assert_failonerror(
             input_fn=partial(rowmap, input_, mapper, header=('foo',)),
             expected_output=expect_)
 
@@ -251,7 +251,7 @@ def test_rowmapmany_failonerror():
     mapper  = lambda r: [r[0].lower()]
     expect_ = (('foo',), ('a',), ('b',),)
 
-    test_failonerror(
+    assert_failonerror(
             input_fn=partial(rowmapmany, input_, mapper, header=('foo',)),
             expected_output=expect_)
 

--- a/petl/test/transform/test_validation.py
+++ b/petl/test/transform/test_validation.py
@@ -4,14 +4,12 @@ from __future__ import absolute_import, print_function, division
 
 import logging
 
+import pytest
 
 import petl as etl
 from petl.transform.validation import validate
 from petl.test.helpers import ieq
 from petl.errors import FieldSelectionError
-
-
-from nose.tools import raises
 
 
 logger = logging.getLogger(__name__)
@@ -52,7 +50,6 @@ def test_constraints():
     ieq(expect, actual)
 
 
-@raises(FieldSelectionError)
 def test_non_optional_constraint_with_missing_field():
     constraints = [
         dict(name='C1', field='foo', test=int),
@@ -62,7 +59,8 @@ def test_non_optional_constraint_with_missing_field():
              ('1999-99-99', 'z'))
 
     actual = validate(table, constraints)
-    debug(actual)
+    with pytest.raises(FieldSelectionError):
+        debug(actual)
 
 
 def test_optional_constraint_with_missing_field():

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+log_level=DEBUG

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,8 @@
 wheel
 setuptools
 nose
+pytest-cov==2.12.0
+pytest>=4.6.6
 tox
 coveralls
 coverage

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,5 @@
 wheel
 setuptools
-nose
 pytest-cov==2.12.0
 pytest>=4.6.6
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ setenv =
     py27: PY_MAJOR_VERSION = py2
     py36,py37,py38,py39: PY_MAJOR_VERSION = py3
 commands =
-    py27,py36,py38,py39: nosetests -v petl --with-coverage --cover-package=petl
+    py27,py36,py38,py39: pytest --cov=petl petl
     py37: nosetests -v --with-coverage --cover-package=petl --with-doctest --doctest-options=+NORMALIZE_WHITESPACE petl -I"csv_py2\.py" -I"db\.py"
     coverage report -m
 deps =
@@ -67,7 +67,7 @@ deps =
 setenv =
     {[testenv]setenv}
 commands =
-    nosetests -v petl --with-coverage --cover-package=petl
+    pytest --cov=petl petl
 deps =
     -rrequirements-tests.txt
     -rrequirements-database.txt
@@ -81,4 +81,4 @@ deps =
     SQLAlchemy==1.2.10
     -rrequirements-tests.txt
 commands =
-    nosetests -v --stop petl
+    pytest petl

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,7 @@ setenv =
     py27: PY_MAJOR_VERSION = py2
     py36,py37,py38,py39: PY_MAJOR_VERSION = py3
 commands =
-    py27,py36,py38,py39: pytest --cov=petl petl
-    py37: pytest --cov=petl petl
+    pytest --cov=petl petl
     coverage report -m
 deps =
     :preinstall1: Cython<=0.29.21,>=0.29.13

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv =
     py36,py37,py38,py39: PY_MAJOR_VERSION = py3
 commands =
     py27,py36,py38,py39: pytest --cov=petl petl
-    py37: nosetests -v --with-coverage --cover-package=petl --with-doctest --doctest-options=+NORMALIZE_WHITESPACE petl -I"csv_py2\.py" -I"db\.py"
+    py37: pytest --cov=petl petl
     coverage report -m
 deps =
     :preinstall1: Cython<=0.29.21,>=0.29.13
@@ -55,7 +55,7 @@ setenv =
     PETL_TEST_SMB=smb://WORKGROUP;petl:test@localhost/public/
     PETL_TEST_SFTP=sftp://petl:test@localhost/public/
 commands =
-    nosetests -v petl --with-coverage --cover-package=petl
+    pytest --cov=petl petl
 deps =
     {[testenv]deps}
     -rrequirements-remote.txt


### PR DESCRIPTION
This PR has the objective of migrating the current nosetest runner to pytest.
Successfully ran the whole test suite against py3.8 with the exception of bcolz.
This the minimal effort and test suite code change required to use pytest.


## Changes

1. The existing conditional checks have been rewritten / added to conform with pytest assertions
2. Expected exceptions rewritten to use `.raises`
3. Tests to be skipped are skipped using pytest 
4. Additionally a fix to close the opened connections in `_iter_sqlalchemy_engine` has been commited

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [ ] Code
  * [x] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes documented in docs/changes.rst
* [ ] Testing
  * [x] \(Optional) Tested local against remote servers
  * [ ] Travis CI passes (unit tests run under Linux)
  * [ ] AppVeyor CI passes (unit tests run under Windows)
  * [ ] Unit test coverage has not decreased (see Coveralls)
* [ ] Changes
  * [ ] \(Optional) Just a proof of concept
  * [x] \(Optional) Work in progress
  * [x] Ready to review
  * [ ] Ready to merge
