### PR TITLE
Add support to testing and debugging with pytest on VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,56 +2,17 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Nose: Test File",
-            "type": "python",
-            "request": "launch",
-            "stopOnEntry": false,
-            "program": "${workspaceRoot}/.vscode/run_nose.py",
-            "cwd": "${workspaceRoot}",
-            "args": [
-                "-v", // additional nose parameters –
-                "${file}", // currently selected file
-            ],
-            "env": {
-                "PETL": "Rocks",
-                // docker run -it --name samba -p 139:139 -p 445:445 -d "dperson/samba" -p -u "user1;pass1" -s "public;/public-dir;yes;no;yes;all"
-                // "PETL_TEST_SMB": "smb://WORKGROUP;user1:pass1@localhost/public/",
-                // docker run -it --name sftp -p 22:22 -d atmoz/sftp user2:pass2:::public
-                // "PETL_TEST_SFTP": "sftp://user1:pass1@localhost/public/"
-            }
-        },
-        {
-            "name": "Nose: Test Function",
-            "type": "python",
-            "request": "launch",
-            "stopOnEntry": false,
-            "program": "${workspaceRoot}/.vscode/run_nose.py",
-            "cwd": "${workspaceRoot}",
-            "args": [
-                "-v", // additional nose parameters –
-                "--testmatch=${input:testfilter}",
-                "${file}", // currently selected file
-            ],
-            "env": {
-                "PETL": "Rocks",
-                // "PETL_TEST_SMB": "smb://WORKGROUP;user1:pass1@localhost/public/",
-                // "PETL_TEST_SFTP": "sftp://user1:pass1@localhost/public/"
-            }
-        },
-        {
             "name": "Python: Debug File",
             "type": "python",
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal"
         },
-    ],
-    "inputs": [
         {
-            "id": "testfilter",
-            "description": "Function for testing",
-            "type": "promptString",
-            "default": ""
+            "name": "Python: Module",
+            "type": "python",
+            "request": "launch",
+            "module": "petl"
         }
     ]
 }

--- a/.vscode/run_nose.py
+++ b/.vscode/run_nose.py
@@ -1,2 +1,0 @@
-import nose
-nose.run()

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -123,4 +123,6 @@
         // "--follow-imports",
         // "silent",
     ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,53 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Package: build",
+            "command": "python2",
+            "args": [
+                "setup.py",
+                "build"
+            ],
+            "presentation": {
+                "echo": true,
+                "panel": "shared",
+                "focus": true
+            }
+        },
+        {
+            "label": "Package: install",
+            "command": "python3",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "args": [
+                "setup.py",
+                "install"
+            ],
+            "presentation": {
+                "echo": true,
+                "panel": "shared",
+                "focus": true
+            }
+        }
+    ],
+    "problemMatcher": [
+        {
+            "fileLocation": "absolute",
+            "pattern": [
+                {
+                    "regexp": "^\\s+File \"(.*)\", line (\\d+), in (.*)$",
+                    "file": 1,
+                    "line": 2
+                },
+                {
+                    "regexp": "^\\s+(.*)$",
+                    "message": 1
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR has the objective of integrating recently migrated pytest into VSCode

## Changes

1. Removed `nosetests` hacks
2. Enabled testing and debugging with pytest directly on VSCode
3. Added VSCode tasks for package build and install

Also:
- These changes only affect developers using VSCode.
- Detection is automatic when opening the local folder from the git clone

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [ ] ~~Code~~
  * [ ] ~~Includes unit tests~~
  * [ ] ~~New functions have docstrings with examples that can be run with doctest~~
  * [ ] ~~New functions are included in API docs~~
  * [ ] ~~Docstrings include notes for any changes to API or behaviour~~
  * [ ] All changes documented in docs/changes.rst
* [ ] Testing
  * [ ] ~~\(Optional) Tested local against remote servers~~
  * [ ] Github CI passes (unit tests run under Linux/Windows/MacOS)
  * [ ] AppVeyor CI passes (unit tests run under Windows)
  * [ ] Unit test coverage has not decreased (see Coveralls)
* [ ] Changes
  * [ ] ~~\(Optional) Work in progress~~
  * [X] Ready to review
  * [X] Ready to merge
