### PR TITLE
ci: run full doctests from python 3.6 to 3.10

### DIFF
--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -121,7 +121,7 @@ jobs:
           python -m pip install --prefer-binary -r requirements-formats.txt
           echo "::endgroup::"
           echo "::group::Perform doctest-modules execution with coverage"
-          pytest --doctest-modules --ignore-glob='*_py2.py' --cov=petl petl
+          pytest --doctest-modules --ignore-glob='*_py2.py'  --ignore-glob='petl/io/db.py' --cov=petl petl
           echo "::endgroup::"
 
       - name: Coveralls

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -118,10 +118,10 @@ jobs:
         if: env.testing == 'full'
         run: |
           echo "::group::Install extra packages test dependencies"
-          python -m pip install -r requirements-formats.txt
+          python -m pip install --prefer-binary -r requirements-formats.txt
           echo "::endgroup::"
           echo "::group::Perform doc test execution with coverage"
-          pytest --cov=petl petl
+          pytest --doctest-modules --ignore-glob='*_py2.py' --cov=petl petl
           echo "::endgroup::"
 
       - name: Coveralls

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements-tests.txt
+          python -m pip install --prefer-binary -r requirements-tests.txt
 
       - name: Setup environment variables for remote filesystem testing
         if: matrix.os == 'ubuntu-latest' && matrix.python == '3.8'
@@ -68,7 +68,7 @@ jobs:
           echo "Setup SFTP environment variable to trigger testing in Petl"
           echo 'PETL_TEST_SFTP=sftp://petl:test@localhost:2244/public/' >> $GITHUB_ENV
           echo "::group::Install remote test dependencies"
-          python -m pip install -r requirements-remote.txt
+          python -m pip install --prefer-binary -r requirements-remote.txt
           echo "::endgroup::"
 
       - name: Install optinal test dependencies for mode ${{ env.testing }}
@@ -104,7 +104,7 @@ jobs:
           docker run -it --name postgres -p 5432:5432 -e POSTGRES_DB=petl -e POSTGRES_USER=petl -e POSTGRES_PASSWORD=test -d postgres:latest
           echo "::endgroup::"
           echo "::group::Install database test dependencies"
-          python -m pip install -r requirements-database.txt
+          python -m pip install --prefer-binary -r requirements-database.txt
           echo "::endgroup::"
 
       - name: Setup petl package
@@ -153,7 +153,7 @@ jobs:
 
       - name: Install doc generation dependencies
         run: |
-          python -m pip install -r requirements-docs.txt
+          python -m pip install --prefer-binary -r requirements-docs.txt
 
       - name: Setup petl package
         run: python setup.py build

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -37,8 +37,7 @@ jobs:
     steps:
       - name: Determine what scope of testing is available on ${{ matrix.os }}
         if: |
-          matrix.python >= '3.6' && matrix.python != '3.9' && matrix.python != '3.10' &&
-          (matrix.os != 'windows-latest' || matrix.python == '3.8')
+          matrix.python >= '3.6' && (matrix.os != 'windows-latest' || matrix.python >= '3.8')
         run: |
           echo 'testing=full' >> $GITHUB_ENV
 

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Determine what scope of testing is available on ${{ matrix.os }}
         if: |
-          matrix.python >= '3.6' && (matrix.os != 'windows-latest' || matrix.python >= '3.8')
+          (matrix.python >= '3.' ) && ( matrix.os != 'windows-latest' )
         run: |
           echo 'testing=full' >> $GITHUB_ENV
 
@@ -120,7 +120,7 @@ jobs:
           echo "::group::Install extra packages test dependencies"
           python -m pip install --prefer-binary -r requirements-formats.txt
           echo "::endgroup::"
-          echo "::group::Perform doc test execution with coverage"
+          echo "::group::Perform doctest-modules execution with coverage"
           pytest --doctest-modules --ignore-glob='*_py2.py' --cov=petl petl
           echo "::endgroup::"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 log_level=DEBUG
+doctest_optionflags = NORMALIZE_WHITESPACE ALLOW_UNICODE

--- a/requirements-formats.txt
+++ b/requirements-formats.txt
@@ -1,5 +1,6 @@
 Cython<0.29.21,>=0.29.13
-numpy<=1.19.2,>=1.16.4
+numpy<=1.19.2,>=1.16.4 ; python_version < '3.10'
+numpy ; python_version >= '3.10'
 numexpr<=2.7.1,>=2.6.9
 intervaltree==3.0.2
 lxml==4.6.5

--- a/requirements-formats.txt
+++ b/requirements-formats.txt
@@ -5,6 +5,7 @@ intervaltree==3.0.2
 lxml==4.6.5
 openpyxl==2.6.2
 pandas<=1.1.2,>=0.24.2 ; python_version < '3.9'
+pandas ; python_version >= '3.9'
 tables
 Whoosh==2.7.4
 xlrd==2.0.1


### PR DESCRIPTION
This PR has the objective of enabling doctests on python 3.9 and 3.10

## Changes

1. Enabled doctests from python 3.6 to 3.10
2. Except on windows that doctests are enabled from python 3.8 to 3.10

## Context

- Before we cant do this because python3.10 is not compatible with `nosetests`.
- But after #584 was merged @arturponinski cleared this issue.

## Checklist

Checklist for for pull requests including new code and/or changes to existing code...

* [X] Code
  * [X] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes documented in docs/changes.rst
* [ ] Testing
  * [ ] \(Optional) Tested local against remote servers
  * [x] Github Actions passes (unit tests run under Linux)
  * [x] AppVeyor CI passes (unit tests run under Windows)
  * [x] Unit test coverage has not decreased (see Coveralls)
* [ ] Changes
  * [ ] \(Optional) Just a proof of concept
  * [ ] \(Optional) Work in progress
  * [x] Ready to review
  * [x] Ready to merge
