### PR TITLE
cd: publish releases to PyPI with GA

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install pypa/build
+        run: |
+          python -m pip install build --user
+
+      - name: Build the petl package as source tarball
+        run: |
+          # python setup.py sdist
+          python -m build --sdist --outdir dist/ .
+
+      - name: Publish the package version ${{ github.event.release.tag_name }} to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          print_hash: true


### PR DESCRIPTION
This PR has the objective of fixing the release to PyPI

## Changes

1. Added new  workflow using Github Actions
2. The workflow will be triggered when publishing a new release on Github
3. This assumes that:
  1.  The `master` branch has no issues and builds with no error
  2. Testing and review of changes already happened using pull requests
  3. Changes are documented in [docs/changes.rst](docs/changes.rst)
  4. There is a summary of the changes in the release description
4. Only release to PyPI is tackled in this PR
5. Conda-Forge and readthedocs.org will be fixed further
6. Testing on PR does not apply. This workflow will be tested with the release `v1.7.6`

## Checklist

Checklist for pull requests including new code and/or changes to existing code...

* [ ] ~~Code~~
  * [ ] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes documented in docs/changes.rst
* [ ] ~~Testing~~
  * [ ] ~~Tested local against remote servers~~
  * [ ] Github Actions CI passes (unit tests run under Linux)
  * [ ] AppVeyor CI passes (unit tests run under Windows)
  * [ ] Unit test coverage has not decreased (see Coveralls)
* [ ] Changes
  * [ ] \(Optional) Just a proof of concept
  * [X] \(Optional) Work in progress
  * [X] Ready to review
  * [ ] Ready to merge
