### PR TITLE
Add workflow_dispatch to publish-release github action to allow manua…

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,6 +3,7 @@ name: release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   pypi:


### PR DESCRIPTION
…l publishing


This PR has the objective of allowing manual publishing of releases (in case of failure and to release missing 1.7.5 to PyPI)