### PR TITLE
Fix sorting of rows with different length using custom itemgetter

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,9 @@ Version 1.7.8
 * Add casting of headers to strings in toxlsx and appendxlsx
   By :user:`arturponinski`, :issue:`530`.
 
+* Fix sorting of rows with different length
+  By :user:`arturponinski`, :issue:`385`.
+
 Version 1.7.7
 -------------
 

--- a/petl/comparison.py
+++ b/petl/comparison.py
@@ -107,23 +107,23 @@ def comparable_itemgetter(*args):
     getter = operator.itemgetter(*args)
     getter_with_default = _itemgetter_with_default(*args)
 
-    def getter_with_fallback(x):
+    def _getter_with_fallback(obj):
         try:
-            return getter(x)
+            return getter(obj)
         except (IndexError, KeyError):
-            return getter_with_default(x)
-    g = lambda x: Comparable(getter_with_fallback(x))
+            return getter_with_default(obj)
+    g = lambda x: Comparable(_getter_with_fallback(x))
     return g
 
 
 def _itemgetter_with_default(*args):
     """ itemgetter compatible with `operator.itemgetter` behavior, filling missing
     values with default instead of raising IndexError or KeyError """
-    def get_default(obj, item, default):
+    def _get_default(obj, item, default):
         try:
             return obj[item]
         except (IndexError, KeyError):
             return default
     if len(args) == 1:
-        return partial(get_default, item=args[0], default=None)
-    return lambda obj: tuple(get_default(obj, item=item, default=None) for item in args)
+        return partial(_get_default, item=args[0], default=None)
+    return lambda obj: tuple(_get_default(obj, item=item, default=None) for item in args)

--- a/petl/comparison.py
+++ b/petl/comparison.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 
 import operator
-
+from functools import partial
 
 from petl.compat import text_type, binary_type, numeric_types
 
@@ -104,6 +104,26 @@ def _typestr(x):
 
 
 def comparable_itemgetter(*args):
-    f = operator.itemgetter(*args)
+    getter = operator.itemgetter(*args)
+    getter_with_default = _itemgetter_with_default(*args)
+
+    def f(x):
+        try:
+            return getter(x)
+        except (IndexError, KeyError):
+            return getter_with_default(x)
     g = lambda x: Comparable(f(x))
     return g
+
+
+def _itemgetter_with_default(*args):
+    """ itemgetter compatible with `operator.itemgetter` behavior, filling missing
+    values with default instead of raising IndexError or KeyError """
+    def get_default(obj, item, default):
+        try:
+            return obj[item]
+        except (IndexError, KeyError):
+            return default
+    if len(args) == 1:
+        return partial(get_default, item=args[0], default=None)
+    return lambda obj: tuple(get_default(obj, item=item, default=None) for item in args)

--- a/petl/comparison.py
+++ b/petl/comparison.py
@@ -107,12 +107,12 @@ def comparable_itemgetter(*args):
     getter = operator.itemgetter(*args)
     getter_with_default = _itemgetter_with_default(*args)
 
-    def f(x):
+    def getter_with_fallback(x):
         try:
             return getter(x)
         except (IndexError, KeyError):
             return getter_with_default(x)
-    g = lambda x: Comparable(f(x))
+    g = lambda x: Comparable(getter_with_fallback(x))
     return g
 
 

--- a/petl/test/transform/test_sorts.py
+++ b/petl/test/transform/test_sorts.py
@@ -9,6 +9,7 @@ import platform
 
 import pytest
 
+import petl
 from petl.compat import next
 
 
@@ -522,3 +523,21 @@ def test_issorted():
     assert not issorted(table5, key='foo')
     assert issorted(table5, key='foo', reverse=True)
     assert not issorted(table5, key='foo', reverse=True, strict=True)
+
+
+def test_sort_missing_cell_numeric():
+    """ Sorting table with missing values raises IndexError #385 """
+    tbl = (('a', 'b'), ('4',), ('2', '1'), ('1',))
+    expect = (('a', 'b'), ('1',), ('2', '1'), ('4',))
+
+    sorted = sort(tbl)
+    ieq(expect, sorted)
+
+
+def test_sort_missing_cell_text():
+    """ Sorting table with missing values raises IndexError #385 """
+    tbl = (('a', 'b', 'c'), ('C',), ('A', '4', '5'))
+    expect = (('a', 'b', 'c'), ('A', '4', '5'), ('C',))
+
+    sorted = sort(tbl)
+    ieq(expect, sorted)

--- a/petl/test/transform/test_sorts.py
+++ b/petl/test/transform/test_sorts.py
@@ -9,7 +9,6 @@ import platform
 
 import pytest
 
-import petl
 from petl.compat import next
 
 
@@ -530,8 +529,8 @@ def test_sort_missing_cell_numeric():
     tbl = (('a', 'b'), ('4',), ('2', '1'), ('1',))
     expect = (('a', 'b'), ('1',), ('2', '1'), ('4',))
 
-    sorted = sort(tbl)
-    ieq(expect, sorted)
+    tbl_sorted = sort(tbl)
+    ieq(expect, tbl_sorted)
 
 
 def test_sort_missing_cell_text():
@@ -539,5 +538,5 @@ def test_sort_missing_cell_text():
     tbl = (('a', 'b', 'c'), ('C',), ('A', '4', '5'))
     expect = (('a', 'b', 'c'), ('A', '4', '5'), ('C',))
 
-    sorted = sort(tbl)
-    ieq(expect, sorted)
+    tbl_sorted = sort(tbl)
+    ieq(expect, tbl_sorted)

--- a/petl/transform/sorts.py
+++ b/petl/transform/sorts.py
@@ -295,7 +295,6 @@ class SortView(Table):
         else:
             indices = range(len(hdr))
         # now use field indices to construct a _getkey function
-        # TODO check if this raises an exception on short rows
         getkey = comparable_itemgetter(*indices)
 
         # TODO support native comparison


### PR DESCRIPTION
This PR has the objective of fixing sorting of rows with different length. Closes https://github.com/petl-developers/petl/issues/385
## Changes

1. Changed `comparable_itemgetter` to fallback to a custom implementation in case of `IndexError` and `KeyError`

## Checklist

Use this checklist for assuring the quality of pull requests that include new code and or make changes to existing code.

* [ ] Source Code rules apply:
  * [x] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [x] All changes are documented in docs/changes.rst
* [ ] Versioning and history tracking rules apply:
  * [x] Using atomic commits when possible
  * [x] Commits are reversible when possible
  * [x] There is no incomplete changes in the pull request
  * [x] There is no accidental garbage added in source code
* [ ] Testing rules apply:
  * [ ] Tested locally using `tox` / `pytest`
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [x] Work in progress / Further changes needed
  * [ ] Ready to review
  * [ ] Ready to merge
