### PR TITLE
github: added a conda forge release status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ DevOps Status
     :alt: PyPI release status
 
 .. image:: https://github.com/conda-forge/petl-feedstock/actions/workflows/automerge.yml/badge.svg
-    :target: https://github.com/conda-forge/petl-feedstock/actions/workflows/automerge.yml/badge.svg
+    :target: https://github.com/conda-forge/petl-feedstock/actions/workflows/automerge.yml
     :alt: Conda Forge release status
 
 .. image:: https://readthedocs.org/projects/petl/badge/?version=stable

--- a/README.rst
+++ b/README.rst
@@ -13,27 +13,31 @@ Resources
 
 - Documentation: http://petl.readthedocs.org/
 - Mailing List: http://groups.google.com/group/python-etl
-- Source Code: https://github.com/petl-developers/petl
-- Download: 
-  - PyPI: http://pypi.python.org/pypi/petl
-  - Conda Forge:https://anaconda.org/conda-forge/petl
+- PyPI: http://pypi.python.org/pypi/petl
+- Conda Forge:https://anaconda.org/conda-forge/petl
 
 DevOps Status
 -------------
 
 .. image:: https://github.com/petl-developers/petl/actions/workflows/test-changes.yml/badge.svg
     :target: https://github.com/petl-developers/petl/actions/workflows/test-changes.yml
-    :alt: continuous integration build status
+    :alt: Continuous Integration build status
 
 .. image:: https://github.com/petl-developers/petl/actions/workflows/publish-release.yml/badge.svg
     :target: https://github.com/petl-developers/petl/actions/workflows/publish-release.yml
-    :alt: continuous delivery release status
+    :alt: PyPI release status
+
+.. image:: https://github.com/conda-forge/petl-feedstock/actions/workflows/automerge.yml/badge.svg
+    :target: https://github.com/conda-forge/petl-feedstock/actions/workflows/automerge.yml/badge.svg
+    :alt: Conda Forge release status
 
 .. image:: https://readthedocs.org/projects/petl/badge/?version=stable
     :target: http://petl.readthedocs.io/en/stable/?badge=stable
+    :alt: readthedocs.org release status
 
 .. image:: https://coveralls.io/repos/github/petl-developers/petl/badge.svg?branch=master
     :target: https://coveralls.io/github/petl-developers/petl?branch=master
+    :alt: Coveralls release status
 
 .. image:: https://zenodo.org/badge/2233194.svg
    :target: https://zenodo.org/badge/latestdoi/2233194


### PR DESCRIPTION
This PR has the objective of providing visibility to Conda Forge continuos delivery pipeline

## Changes

1. Added new badge pointing to conda-forge/petl-feedstock automerge action status
2. Improved badges alt descriptions
3. Release v1.7.7 in [Conda Forge](https://anaconda.org/conda-forge/petl/1.7.7/download/noarch/petl-1.7.7-pyhd8ed1ab_0.tar.bz2)

## Checklist

Use this checklist for assuring the quality of pull requests that include new code and or make changes to existing code.

* [ ] Source Code rules apply:
  * [ ] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes are documented in docs/changes.rst
* [ ] Versioning and history tracking rules apply:
  * [X] Using atomic commits when possible
  * [ ] Commits are reversible when possible
  * [ ] There is no incomplete changes in the pull request
  * [ ] There is no accidental garbage added in source code
* [ ] Testing rules apply:
  * [ ] Tested locally using `tox` / `pytest`
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [X] Ready to review
  * [ ] Ready to merge
