### PR TITLE
fix asindices function used in sortheader to support duplicate values…

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Changes
 Version 1.7.8
 -------------
 
+* Fix sortheader() to not overwrite data for duplicate column names
+  By :user:`arturponinski`, :issue:`392`.
+
 * Add NotImplementedError to IterContainer's __iter__
   By :user:`arturponinski`, :issue:`483`.
 

--- a/petl/test/transform/test_headers.py
+++ b/petl/test/transform/test_headers.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, print_function, division
 from petl.test.helpers import ieq
 from petl.errors import FieldSelectionError
 from petl.util import fieldnames
-from petl.transform.headers import setheader, extendheader, pushheader, skip,\
-    rename, prefixheader, suffixheader
+from petl.transform.headers import setheader, extendheader, pushheader, skip, \
+    rename, prefixheader, suffixheader, sortheader
 
 
 def test_setheader():
@@ -239,4 +239,38 @@ def test_suffixheader():
 
     actual = suffixheader(table1, '_suf')
     ieq(expect, actual)
+    ieq(expect, actual)
+
+
+def test_sortheaders():
+    table1 = (
+        ('id', 'foo', 'bar', 'baz'),
+        ('a', 1, 2, 3),
+        ('b', 4, 5, 6))
+
+    expect = (
+        ('bar', 'baz', 'foo', 'id'),
+        (2, 3, 1, 'a'),
+        (5, 6, 4, 'b'),
+    )
+
+    actual = sortheader(table1)
+    ieq(expect, actual)
+
+
+def test_sortheaders_duplicate_headers():
+    """ Failing test case provided in sortheader()
+    with duplicate column names overlays values #392 """
+    table1 = (
+        ('id', 'foo', 'foo', 'foo'),
+        ('a', 1, 2, 3),
+        ('b', 4, 5, 6))
+
+    expect = (
+        ('foo', 'foo', 'foo', 'id'),
+        (1, 2, 3, 'a'),
+        (4, 5, 6, 'b'),
+    )
+
+    actual = sortheader(table1)
     ieq(expect, actual)

--- a/petl/util/base.py
+++ b/petl/util/base.py
@@ -292,7 +292,9 @@ def asindices(hdr, spec):
             indices.append(s)  # index fields from 0
         # spec could be a field
         elif s in flds:
-            indices.append(flds.index(s))
+            idx = flds.index(s)
+            indices.append(idx)
+            flds[idx] = None  # replace with None to mark as used
         else:
             raise FieldSelectionError(s)
     return indices


### PR DESCRIPTION
… passed to spec


This PR has the objective of supporting duplicate column names in `sortheader`
Closes: https://github.com/petl-developers/petl/issues/392

## Changes

1. Change `asindices` to support passing of duplicate values when sorting non-unique column headers

## Checklist

Use this checklist for assuring the quality of pull requests that include new code and or make changes to existing code.

* [ ] Source Code rules apply:
  * [x] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes are documented in docs/changes.rst
* [ ] Versioning and history tracking rules apply:
  * [x] Using atomic commits when possible
  * [ ] Commits are reversible when possible
  * [x] There is no incomplete changes in the pull request
  * [ ] There is no accidental garbage added in source code
* [ ] Testing rules apply:
  * [x] Tested locally using `tox` / `pytest`
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [x] Ready to review
  * [ ] Ready to merge
