### PR TITLE
Fix iterrowslice to conform with Python 3.7 PEP 479 which transforms …

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Changes
 Version 1.7.8
 -------------
 
+* Fix iterrowslice() to conform with PEP 479
+  By :user:`arturponinski`, :issue:`575`.
+
 * Cleanup and unclutter old and unused files in repository
   By :user:`juarezr`, :issue:`606`.
 

--- a/petl/test/transform/test_basics.py
+++ b/petl/test/transform/test_basics.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function, division
 
+import pytest
 
 from petl.test.helpers import ieq
 from petl.util import expr, empty, coalesce
@@ -458,6 +459,20 @@ def test_head():
               ('c', 5),
               ('d', 7))
     ieq(expect, table2)
+
+
+def test_head_raises_stop_iteration_for_empty_table():
+    table = iter(head([]))
+    with pytest.raises(StopIteration):
+        next(table)  # header
+
+
+def test_head_raises_stop_iteration_for_header_only():
+    table1 = (('foo', 'bar', 'baz'),)
+    table = iter(head(table1))
+    next(table)  # header
+    with pytest.raises(StopIteration):
+        next(table)
 
 
 def test_tail():

--- a/petl/transform/basics.py
+++ b/petl/transform/basics.py
@@ -727,7 +727,10 @@ class RowSliceView(Table):
 
 def iterrowslice(source, sliceargs):
     it = iter(source)
-    yield tuple(next(it))  # fields
+    try:
+        yield tuple(next(it))  # fields
+    except StopIteration:
+        return
     for row in islice(it, *sliceargs):
         yield tuple(row)
 


### PR DESCRIPTION
…StopIteration in generators to RuntimeError exceptions


This PR has the objective of aligning `iterrowslice` with Python 3.7 PEP 479 behavior, which transforms StopIteration in generators to RuntimeError exceptions.

## Changes

1. Added exception handler for the first `yield`


## Checklist

Use this checklist for assuring the quality of pull requests that include new code and or make changes to existing code.

* [ ] Source Code rules apply:
  * [x] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [x] All changes are documented in docs/changes.rst
* [ ] Versioning and history tracking rules apply:
  * [x] Using atomic commits when possible
  * [x] Commits are reversible when possible
  * [x] There is no incomplete changes in the pull request
  * [x] There is no accidental garbage added in source code
* [ ] Testing rules apply:
  * [x] Tested locally using `tox` / `pytest`
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [x] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [ ] Ready to review
  * [ ] Ready to merge
