### PR TITLE
Improve test helpers testing

### DIFF
--- a/petl/test/helpers.py
+++ b/petl/test/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function, division
 
+import os
 import sys
 
 import pytest
@@ -8,15 +9,18 @@ from petl.compat import izip_longest
 
 
 def eq_(expect, actual, msg=None):
+    """Test when two values from a python variable are exactly equals (==)"""
     assert expect == actual, msg
 
 
 def assert_almost_equal(first, second, places=None, msg=None):
-    abs = None if places is None else 10**-places
-    assert pytest.approx(first, second, abs=abs), msg
+    """Test when the values are aproximatedly equals by a places exponent"""
+    vabs = None if places is None else 10 ** (- places)
+    assert pytest.approx(first, second, abs=vabs), msg
+
 
 def ieq(expect, actual, cast=None):
-    '''test when values are equals for eacfh row and column'''
+    """Test when values of a iterable are equals for each row and column"""
     ie = iter(expect)
     ia = iter(actual)
     for re, ra in izip_longest(ie, ia, fillvalue=None):
@@ -36,32 +40,17 @@ def ieq(expect, actual, cast=None):
 
 
 def _eq_print(ve, va, re, ra):
+    """Print two values when they aren't exactly equals (==)"""
     try:
         eq_(ve, va)
     except AssertionError as ea:
+        # Show the values but only when they differ
         print('\nrow: ', re, ' != ', ra, file=sys.stderr)
         print('val: ', ve, ' != ', va, file=sys.stderr)
         raise ea
 
 
 def ieq2(expect, actual, cast=None):
-    '''test twice when values are equals for eacfh row and column'''
+    """Test when iterables values are equals twice looking for side effects"""
     ieq(expect, actual, cast)
     ieq(expect, actual, cast)
-
-
-def test_iassertequal():
-    x = ['a', 'b']
-    y = ['a', 'b', 'c']
-    try:
-        ieq(x, y)
-    except AssertionError:
-        pass
-    else:
-        assert False, 'did not catch actual item left over'
-    try:
-        ieq(y, x)
-    except AssertionError:
-        pass
-    else:
-        assert False, 'did not catch expected item left over'

--- a/petl/test/helpers.py
+++ b/petl/test/helpers.py
@@ -64,3 +64,17 @@ def ieq2(expect, actual, cast=None):
     """Test when iterables values are equals twice looking for side effects"""
     ieq(expect, actual, cast)
     ieq(expect, actual, cast)
+
+
+def get_env_vars_named(prefix, remove_prefix=True):
+    """Get all named variables starting with prefix"""
+    res = {}
+    varlen = len(prefix)
+    for varname, varvalue in os.environ.items():
+        if varname.upper().startswith(prefix.upper()):
+            if remove_prefix:
+                varname = varname[varlen:]
+            res[varname] = varvalue
+    if len(res) == 0:
+        return None
+    return res

--- a/petl/test/helpers.py
+++ b/petl/test/helpers.py
@@ -23,6 +23,7 @@ def ieq(expect, actual, cast=None):
     """Test when values of a iterable are equals for each row and column"""
     ie = iter(expect)
     ia = iter(actual)
+    ir = 0
     for re, ra in izip_longest(ie, ia, fillvalue=None):
         if cast:
             ra = cast(ra)
@@ -31,22 +32,31 @@ def ieq(expect, actual, cast=None):
         if type(re) in (int, float, bool, str):
             eq_(re, ra)
             continue
-        for ve, va in izip_longest(re, ra, fillvalue=None):
-            if isinstance(ve, list):
-                for je, ja in izip_longest(ve, va, fillvalue=None):
-                    _eq_print(je, ja, re, ra)
-            elif not isinstance(ve, dict):
-                _eq_print(ve, va, re, ra)
+        _ieq_row(re, ra, ir)
+        ir = ir + 1
 
 
-def _eq_print(ve, va, re, ra):
+def _ieq_row(re, ra, ir):
+    assert ra is not None, "Expected row #%d is None, but result row is not None" % ir
+    assert re is not None, "Expected row #%d is not None, but result row is None" % ir
+    ic = 0
+    for ve, va in izip_longest(re, ra, fillvalue=None):
+        if isinstance(ve, list):
+            for je, ja in izip_longest(ve, va, fillvalue=None):
+                _ieq_col(je, ja, re, ra, ir, ic)
+        elif not isinstance(ve, dict):
+            _ieq_col(ve, va, re, ra, ir, ic)
+        ic = ic + 1
+
+
+def _ieq_col(ve, va, re, ra, ir, ic):
     """Print two values when they aren't exactly equals (==)"""
     try:
         eq_(ve, va)
     except AssertionError as ea:
         # Show the values but only when they differ
-        print('\nrow: ', re, ' != ', ra, file=sys.stderr)
-        print('val: ', ve, ' != ', va, file=sys.stderr)
+        print('\nrow #%d' % ir, re, ' != ', ra, file=sys.stderr)
+        print('col #%d: ' % ic, ve, ' != ', va, file=sys.stderr)
         raise ea
 
 

--- a/petl/test/io/test_xml.py
+++ b/petl/test/io/test_xml.py
@@ -476,7 +476,7 @@ def test_toxml12():
 def test_toxml13():
     _check_toxml(
         _TABLE1, _BODY1,
-        check=('//tr', ('td', 'th')),
+        check=('.//tr', ('td', 'th')),
         style=' <tr><td>{ABCD}</td><td>{N123}</td></tr>\n',
         root='table',
         rows='tbody'
@@ -558,7 +558,7 @@ def test_toxml18():
     _TAB_AHZ = _ROW_A0 + _HEAD1 + _BODY1 + _ROW_Z9
     _check_toxml(
         _TABLE1, _TAB_AHZ,
-        check=('//row', 'col'),
+        check=('.//row', 'col'),
         head='thead/row/col',
         rows='row/col',
         prologue=_TAG_TOP + _TAG_A0, 
@@ -579,7 +579,7 @@ def test_toxml19():
 def test_toxml20():
     _check_toxml(
         _TABLE1, _TABLE1,
-        check=('//line', 'cell'),
+        check=('.//line', 'cell'),
         root='book',
         head='thead/line/cell',
         rows='tbody/line/cell',

--- a/petl/test/test_comparison.py
+++ b/petl/test/test_comparison.py
@@ -4,8 +4,9 @@ from __future__ import print_function, division, absolute_import
 from datetime import datetime
 from decimal import Decimal
 
+import pytest
 
-from petl.test.helpers import eq_
+from petl.test.helpers import eq_, ieq
 from petl.comparison import Comparable
 
 
@@ -178,3 +179,25 @@ def test_comparable_nested():
          (b'aa', -1),
          [b'aa', False]]
     eq_(e, a)
+
+
+def test_comparable_ieq_table():
+    rows = [[u'Bob', 42, 33],
+          [u'Jim', 13, 69],
+          [u'Joe', 86, 17],
+          [u'Ted', 23, 51]]
+    ieq(rows, rows)
+
+
+def test_comparable_ieq_rows():
+    rows = [['a', 'b', 'c'], [1, 2]]
+    ieq(rows, rows)
+
+
+def test_comparable_ieq_missing():
+    x = ['a', 'b', 'c']
+    y = ['a', 'b']
+    with pytest.raises(AssertionError):
+        ieq(x, y)
+    with pytest.raises(AssertionError):
+        ieq(y, x)

--- a/petl/test/test_helpers.py
+++ b/petl/test/test_helpers.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, division
+
+import pytest
+
+from petl.test.helpers import eq_, ieq, get_env_vars_named
+
+GET_ENV_PREFIX = "PETL_TEST_HELPER_ENVVAR_"
+
+
+def _testcase_get_env_vars_named(num_vals, prefix=""):
+    res = {}
+    for i in range(1, num_vals, 1):
+        reskey = prefix + str(i)
+        res[reskey] = str(i)
+    return res
+
+
+@pytest.fixture()
+def setup_helpers_get_env_vars_named(monkeypatch):
+    varlist = _testcase_get_env_vars_named(3, prefix=GET_ENV_PREFIX)
+    for k, v in varlist.items():
+        monkeypatch.setenv(k, v)
+
+
+def test_helper_get_env_vars_named_prefixed(setup_helpers_get_env_vars_named):
+    expected = _testcase_get_env_vars_named(3, GET_ENV_PREFIX)
+    found = get_env_vars_named(GET_ENV_PREFIX, remove_prefix=False)
+    ieq(found, expected)
+
+
+def test_helper_get_env_vars_named_unprefixed(setup_helpers_get_env_vars_named):
+    expected = _testcase_get_env_vars_named(3)
+    found = get_env_vars_named(GET_ENV_PREFIX, remove_prefix=True)
+    ieq(found, expected)
+
+
+def test_helper_get_env_vars_named_not_found(setup_helpers_get_env_vars_named):
+    expected = None
+    found = get_env_vars_named("PETL_TEST_HELPER_ENVVAR_NOT_FOUND_")
+    eq_(found, expected)

--- a/petl/transform/regex.py
+++ b/petl/transform/regex.py
@@ -24,7 +24,7 @@ def capture(table, field, pattern, newfields=None, include_original=False,
         ...           ['2', 'A2', '15'],
         ...           ['3', 'B1', '18'],
         ...           ['4', 'C12', '19']]
-        >>> table2 = etl.capture(table1, 'variable', '(\\w)(\\d+)',
+        >>> table2 = etl.capture(table1, 'variable', '([A-Z,a-z]+)([0-9]+)',
         ...                      ['treat', 'time'])
         >>> table2
         +-----+-------+-------+------+
@@ -40,7 +40,7 @@ def capture(table, field, pattern, newfields=None, include_original=False,
         +-----+-------+-------+------+
 
         >>> # using the include_original argument
-        ... table3 = etl.capture(table1, 'variable', '(\\w)(\\d+)',
+        ... table3 = etl.capture(table1, 'variable', '([A-Z,a-z]+)([0-9]+)',
         ...                      ['treat', 'time'],
         ...                      include_original=True)
         >>> table3
@@ -65,7 +65,6 @@ def capture(table, field, pattern, newfields=None, include_original=False,
     expression. If ``fill`` is ``None`` (default) then a
     ``petl.transform.TransformError`` will be raised on the first non-matching
     value.
-
     """
 
     return CaptureView(table, field, pattern,
@@ -457,4 +456,3 @@ def itersplitdown(table, field, pattern, maxsplit, flags):
         value = row[field_index]
         for v in prog.split(value, maxsplit):
             yield tuple(v if i == field_index else row[i] for i in range(len(hdr)))
-


### PR DESCRIPTION
This PR has the objective of improving pytest helpers testing

## Changes

1. Added new helper `get_env_vars_named` available for pytest for further use
2. Fixed a bug in test helper `ieq`
3. Fixed warnings in pytest of `xml` and `transform.regex.capture`
4. Improved the docs about test helper `ieq`, `eq_`

## Checklist

Use this checklist for assuring the quality of pull requests that include new code and or make changes to existing code.

* [X] Source Code rules apply:
  * [X] Includes unit tests
  * [X] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [X] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes are documented in docs/changes.rst
* [X] Versioning and history tracking rules apply:
  * [X] Using atomic commits when possible
  * [X] Commits are reversible when possible
  * [ ] There is no incomplete changes in the pull request
  * [ ] There is no accidental garbage added in source code
* [X] Testing rules apply:
  * [X] Tested locally using `tox` / `pytest`
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [X] Ready to review
  * [X] Ready to merge
