### PR TITLE
Fix fromtsv() to pass on header argument

### DIFF
--- a/petl/io/csv.py
+++ b/petl/io/csv.py
@@ -71,7 +71,7 @@ def fromtsv(source=None, encoding=None, errors='strict', header=None,
     """
 
     csvargs.setdefault('dialect', 'excel-tab')
-    return fromcsv(source, encoding=encoding, errors=errors, **csvargs)
+    return fromcsv(source, encoding=encoding, errors=errors, header=header, **csvargs)
 
 
 def tocsv(table, source=None, encoding=None, errors='strict', write_header=True,


### PR DESCRIPTION
fromtsv() is a helper that calls fromcsv() with a different dialect set. However it was not passing on the header argument.

I apologize – I have not run unit tests, but the fix seems very straightforward and I figured a pull request was probably still more helpful than just raising a bug report.