### PR TITLE
Fix fromdictsgenerator separate function

### DIFF
--- a/docs/io.rst
+++ b/docs/io.rst
@@ -153,6 +153,7 @@ JSON files
 
 .. autofunction:: petl.io.json.fromjson
 .. autofunction:: petl.io.json.fromdicts
+.. autofunction:: petl.io.json.fromdictsgenerator
 .. autofunction:: petl.io.json.tojson
 .. autofunction:: petl.io.json.tojsonarrays
 

--- a/petl/io/__init__.py
+++ b/petl/io/__init__.py
@@ -17,7 +17,7 @@ from petl.io.xml import fromxml, toxml
 
 from petl.io.html import tohtml, teehtml
 
-from petl.io.json import fromjson, tojson, tojsonarrays, fromdicts
+from petl.io.json import fromjson, tojson, tojsonarrays, fromdicts, fromdictsgenerator
 
 from petl.io.db import fromdb, todb, appenddb
 

--- a/petl/io/json.py
+++ b/petl/io/json.py
@@ -227,11 +227,12 @@ class DictsGeneratorView(DictsView):
         yield self._header
 
         if not self._filecache:
-            self._filecache = NamedTemporaryFile(delete=False, mode='wb', buffering=0)
+            self._filecache = NamedTemporaryFile(delete=False, mode='wb')
             it = iter(self.dicts)
             for o in it:
                 row = tuple(o[f] if f in o else self.missing for f in self._header)
                 pickle.dump(row, self._filecache, protocol=-1)
+            self._filecache.flush()
             self._filecache.close()
 
         for row in iterchunk(self._filecache.name):

--- a/petl/test/io/test_json.py
+++ b/petl/test/io/test_json.py
@@ -241,6 +241,10 @@ def test_fromdictsgenerator_random_generator():
     second_row2 = next(it2)
     assert first_row1 == second_row1
     assert first_row2 == second_row2
-    assert next(it1) == next(it2)
+    # reverse order
+    second_row3 = next(it2)
+    first_row3 = next(it1)
+    assert second_row3 == first_row3
     ieq(actual, actual)
     assert actual.header() == ('n', 'foo', 'bar')
+    assert len(actual) == 6

--- a/petl/transform/sorts.py
+++ b/petl/transform/sorts.py
@@ -14,6 +14,7 @@ from petl.compat import pickle, next, text_type
 import petl.config as config
 from petl.comparison import comparable_itemgetter
 from petl.util.base import Table, asindices
+from petl.util.base import iterchunk as _iterchunk
 
 
 logger = logging.getLogger(__name__)
@@ -113,18 +114,6 @@ def sort(table, key=None, reverse=False, buffersize=None, tempdir=None,
 
 
 Table.sort = sort
-
-
-def _iterchunk(fn):
-    # reopen so iterators from file cache are independent
-    debug('iterchunk, opening %s' % fn)
-    with open(fn, 'rb') as f:
-        try:
-            while True:
-                yield pickle.load(f)
-        except EOFError:
-            pass
-    debug('end of iterchunk, closed %s' % fn)
 
 
 class _Keyed(namedtuple('Keyed', ['key', 'obj'])):

--- a/petl/util/base.py
+++ b/petl/util/base.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, division
 
-
+import logging
+import pickle
 import re
 from itertools import islice, chain, cycle, product,\
     permutations, combinations, takewhile, dropwhile, \
@@ -15,6 +16,9 @@ from petl.compat import imap, izip, izip_longest, ifilter, ifilterfalse, \
 from petl.errors import FieldSelectionError
 from petl.comparison import comparable_itemgetter
 
+
+logger = logging.getLogger(__name__)
+debug = logger.debug
 
 class IterContainer(object):
 
@@ -740,6 +744,18 @@ def iterpeek(it, n=1):
     else:
         peek = list(islice(it, n))
         return peek, chain(peek, it)
+
+
+def iterchunk(fn):
+    # reopen so iterators from file cache are independent
+    debug('iterchunk, opening %s' % fn)
+    with open(fn, 'rb') as f:
+        try:
+            while True:
+                yield pickle.load(f)
+        except EOFError:
+            pass
+    debug('end of iterchunk, closed %s' % fn)
 
 
 def empty():


### PR DESCRIPTION
This PR has the objective of improving the support of generators in `fromdicts`. THe current implementation uses `itertools.tee` which according to docs and production deployments uses large amounts of memory, leading to out of memory kills of processes. This PR aims to revert the functionality and introduce a dedicated `fromdictsgenerator` function, which uses filecache, similar to sorting.

## Changes

1. Added new `fromdictsgenerator` to `petl.io.json`
2. Reverted the detection of generators in `fromdicts` introduced in 1.7.5 and added a warning about passing the generator to `fromdicts`
3. Added info about the function to docs
4. Moved `_iterchunk` from sorts to `petl.util.base`. Imported to sorts as `_iterchunk` for BC

## Checklist

Use this checklist for assuring the quality of pull requests that include new code and or make changes to existing code.

* [ ] Source Code rules apply:
  * [x] Includes unit tests
  * [x] New functions have docstrings with examples that can be run with doctest
  * [x] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes are documented in docs/changes.rst
* [ ] Versioning and history tracking rules apply:
  * [x] Using atomic commits when possible
  * [x] Commits are reversible when possible
  * [x] There is no incomplete changes in the pull request
  * [x] There is no accidental garbage added in source code
* [ ] Testing rules apply:
  * [x] Tested locally using `tox` / `pytest`
  * [x] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [x] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [x] Ready to review
  * [x] Ready to merge
