### PR TITLE
Fix generator support in fromdicts - use file cache instead of iterto…

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 1.7.11
+--------------
+
+* Fix generator support in fromdicts to use file cache
+  By :user:`arturponinski`, :issue:`625`.
+
 Version 1.7.10
 --------------
 

--- a/petl/io/json.py
+++ b/petl/io/json.py
@@ -142,6 +142,24 @@ def fromdicts(dicts, header=None, sample=1000, missing=None):
         | 'c' |   2 |
         +-----+-----+
 
+    Argument `dicts` can also be a generator, the output of generator
+    is iterated and cached using a temporary file to support further
+    transforms and multiple passes of the table:
+
+        >>> import petl as etl
+        >>> dicts = ({"foo": chr(ord("a")+i), "bar":i+1} for i in range(3))
+        >>> table1 = etl.fromdicts(dicts, header=['foo', 'bar'])
+        >>> table1
+        +-----+-----+
+        | foo | bar |
+        +=====+=====+
+        | 'a' |   1 |
+        +-----+-----+
+        | 'b' |   2 |
+        +-----+-----+
+        | 'c' |   3 |
+        +-----+-----+
+
     If `header` is not specified, `sample` items from `dicts` will be
     inspected to discovery dictionary keys. Note that the order in which
     dictionary keys are discovered may not be stable,
@@ -157,6 +175,16 @@ def fromdicts(dicts, header=None, sample=1000, missing=None):
     an explicit `header` or to use another function like
     :func:`petl.transform.headers.sortheader` on the resulting table to
     guarantee stability.
+
+    .. versionchanged:: 1.7.5
+
+    Full support of generators passed as `dicts` has been added, leveraging
+    `itertools.tee`.
+
+    .. versionchanged:: 1.7.11
+
+    Generator support has been modified to use temporary file cache
+    instead of `itertools.tee` due to high memory usage.
 
     """
     view = DictsGeneratorView if inspect.isgenerator(dicts) else DictsView

--- a/petl/transform/sorts.py
+++ b/petl/transform/sorts.py
@@ -14,6 +14,7 @@ from petl.compat import pickle, next, text_type
 import petl.config as config
 from petl.comparison import comparable_itemgetter
 from petl.util.base import Table, asindices
+from petl.util.base import iterchunk as _iterchunk
 
 
 logger = logging.getLogger(__name__)
@@ -113,18 +114,6 @@ def sort(table, key=None, reverse=False, buffersize=None, tempdir=None,
 
 
 Table.sort = sort
-
-
-def _iterchunk(fn):
-    # reopen so iterators from file cache are independent
-    debug('iterchunk, opening %s' % fn)
-    with open(fn, 'rb') as f:
-        try:
-            while True:
-                yield pickle.load(f)
-        except EOFError:
-            pass
-    debug('end of iterchunk, closed %s' % fn)
 
 
 class _Keyed(namedtuple('Keyed', ['key', 'obj'])):

--- a/petl/util/base.py
+++ b/petl/util/base.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, division
 
-
+import logging
+import pickle
 import re
 from itertools import islice, chain, cycle, product,\
     permutations, combinations, takewhile, dropwhile, \
@@ -15,6 +16,9 @@ from petl.compat import imap, izip, izip_longest, ifilter, ifilterfalse, \
 from petl.errors import FieldSelectionError
 from petl.comparison import comparable_itemgetter
 
+
+logger = logging.getLogger(__name__)
+debug = logger.debug
 
 class IterContainer(object):
 
@@ -740,6 +744,18 @@ def iterpeek(it, n=1):
     else:
         peek = list(islice(it, n))
         return peek, chain(peek, it)
+
+
+def iterchunk(fn):
+    # reopen so iterators from file cache are independent
+    debug('iterchunk, opening %s' % fn)
+    with open(fn, 'rb') as f:
+        try:
+            while True:
+                yield pickle.load(f)
+        except EOFError:
+            pass
+    debug('end of iterchunk, closed %s' % fn)
 
 
 def empty():


### PR DESCRIPTION
…ols.tee


This PR has the objective of improving the support of generators in fromdicts. 
The current implementation uses itertools.tee which according to docs and production deployments uses large amounts of memory, leading to out of memory kills of processes.
This PR aims to keep the improved support of generators by using a filecache, similar to sorting, to allow multiple iterations.

Closes https://github.com/petl-developers/petl/issues/618

## Changes

1. Refactored `DictsGeneratorView` in `petl.io.json` to use file cache
2. Moved _iterchunk from sorts to petl.util.base. Imported to sorts as _iterchunk for BC

## Checklist

Use this checklist for assuring the quality of pull requests that include new code and or make changes to existing code.

* [ ] Source Code rules apply:
  * [x] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behaviour
  * [ ] All changes are documented in docs/changes.rst
* [ ] Versioning and history tracking rules apply:
  * [x] Using atomic commits when possible
  * [x] Commits are reversible when possible
  * [x] There is no incomplete changes in the pull request
  * [x] There is no accidental garbage added in source code
* [x] Testing rules apply:
  * [x] Tested locally using `tox` / `pytest`
  * [x] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [x] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [x] Ready to review
  * [x] Ready to merge
