### PR TITLE
Add Support for JSONL Writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,4 +179,9 @@ example*.*
 
 sketch*
 
+
+# Ignore this folder not idea users
+
+.idea/
+
 ## end of .gitignore file ##

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 1.7.12
+--------------
+
+* Add support for writing to JSONL files
+  By :user:`mzaeemz`, :issue:`524`.
+
 Version 1.7.11
 --------------
 

--- a/petl/test/io/test_jsonl.py
+++ b/petl/test/io/test_jsonl.py
@@ -2,8 +2,9 @@
 from __future__ import absolute_import, print_function, division
 
 from tempfile import NamedTemporaryFile
+import json
 
-from petl import fromjson
+from petl import fromjson, tojson
 from petl.test.helpers import ieq
 
 
@@ -49,3 +50,44 @@ def test_fromjson_2():
 
     ieq(expect, actual)
     ieq(expect, actual)  # verify can iterate twice
+
+
+def test_tojson_1():
+    table = (('foo', 'bar'),
+             ('a', 1),
+             ('b', 2),
+             ('c', 2))
+    f = NamedTemporaryFile(delete=False, mode='r')
+    tojson(table, f.name, lines=True)
+    result = []
+    for line in f:
+        result.append(json.loads(line))
+    assert len(result) == 3
+    assert result[0]['foo'] == 'a'
+    assert result[0]['bar'] == 1
+    assert result[1]['foo'] == 'b'
+    assert result[1]['bar'] == 2
+    assert result[2]['foo'] == 'c'
+    assert result[2]['bar'] == 2
+
+
+def test_tojson_2():
+    table = [['name', 'wins'],
+             ['Gilbert', [['straight', '7S'], ['one pair', '10H']]],
+             ['Alexa', [['two pair', '4S'], ['two pair', '9S']]],
+             ['May', []],
+             ['Deloise', [['three of a kind', '5S']]]]
+    f = NamedTemporaryFile(delete=False, mode='r')
+    tojson(table, f.name, lines=True)
+    result = []
+    for line in f:
+        result.append(json.loads(line))
+    assert len(result) == 4
+    assert result[0]['name'] == 'Gilbert'
+    assert result[0]['wins'] == [['straight', '7S'], ['one pair', '10H']]
+    assert result[1]['name'] == 'Alexa'
+    assert result[1]['wins'] == [['two pair', '4S'], ['two pair', '9S']]
+    assert result[2]['name'] == 'May'
+    assert result[2]['wins'] == []
+    assert result[3]['name'] == 'Deloise'
+    assert result[3]['wins'] == [['three of a kind', '5S']]


### PR DESCRIPTION
This PR has the objective of adding support for writing to JSONL files

## Changes

1. Updated tojson function in petl.io.json to write in JSONL format if `lines` argument is set to true

## Checklist

Use this checklist for assuring the quality of pull requests that include new code and or make changes to existing code.

* [x] Source Code rules apply:
  * [x] Includes unit tests
  * [x] New functions have docstrings with examples that can be run with doctest
  * [x] New functions are included in API docs
  * [x] Docstrings include notes for any changes to API or behaviour
  * [x] All changes are documented in docs/changes.rst
* [ ] Versioning and history tracking rules apply:
  * [x] Using atomic commits when possible
  * [x] Commits are reversible when possible
  * [x] There is no incomplete changes in the pull request
  * [x] There is no accidental garbage added in source code
* [x] Testing rules apply:
  * [x] Tested locally using `tox` / `pytest`
  * [x] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [x] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [x] Ready to review
  * [ ] Ready to merge
