### PR TITLE
Add python3.11 for the build and testing

### DIFF
--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
-        python: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     runs-on: "${{ matrix.os }}"
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -29,7 +29,7 @@ suite with::
     $ pip install -r requirements-tests.txt
     $ pytest -v petl
 
-Currently :mod:`petl` supports Python 2.7, 3.6 up to 3.10
+Currently :mod:`petl` supports Python 2.7, 3.6 up to 3.11
 so the tests should pass under all these Python versions.
 
 Dependencies

--- a/requirements-formats.txt
+++ b/requirements-formats.txt
@@ -5,10 +5,12 @@ intervaltree>=3.0.2
 lxml>=4.6.5
 openpyxl>=2.6.2
 pandas
-tables
 Whoosh>=2.7.4
 xlrd>=2.0.1
 xlwt>=1.3.0
 fastavro>=0.24.2 ; python_version >= '3.4'
 fastavro==0.24.2 ; python_version < '3.0'
 gspread>=3.4.0 ; python_version >= '3.4'
+
+# version 3.7.0 doesn't work yet with python3.11
+tables ; python_version != '3.11'

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,7 +1,14 @@
-# packages bellow need complex local setup
-# throubleshooting: 
-# 1. define the following variable before running pip:
-# $ export DISABLE_BLOSC_AVX2=1
-# 2. pip install --prefer-binary bcolz
+# Packages bellow need complex local setup #
+# Also check: .github/workflows/test-changes.yml
+
+# Throubleshooting: 
+# 1. $ export DISABLE_BLOSC_AVX2=1
+# 2. $ brew install c-blosc
+
 blosc  ; python_version >= '3.7'
-bcolz  ; python_version >= '3.7'
+
+# Throubleshooting: 
+# 1. pip install --prefer-binary -r requirements-optional.txt
+# 2. pip install --prefer-binary bcolz
+
+bcolz  ; python_version >= '3.7' and python_version < '3.10'

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ setup(
                  'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',
                  'Programming Language :: Python :: 3.9',
+                 'Programming Language :: Python :: 3.10',
+                 'Programming Language :: Python :: 3.11',
                  'Topic :: Software Development :: Libraries :: Python Modules'
                  ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,14 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37, py38, py39, py310, {py36,py37,py38,py39,py310}-docs
+envlist = py27, py36, py37, py38, py39, py310, py311, {py36,py37,py38,py39,py310,py311}-docs
 
 [testenv]
 # get stable output for unordered types
 setenv =
     PYTHONHASHSEED = 42
     py27: PY_MAJOR_VERSION = py2
-    py36,py37,py38,py39,py310: PY_MAJOR_VERSION = py3
+    py36,py37,py38,py39,py310,py311: PY_MAJOR_VERSION = py3
 commands =
     pytest --cov=petl petl
     coverage report -m
@@ -19,7 +19,7 @@ deps =
     -rrequirements-tests.txt
     -rrequirements-formats.txt
 
-[testenv:{py36,py37,py38,py39}-docs]
+[testenv:{py36,py37,py38,py39,py310,py311}-docs]
 # build documentation under similar environment to readthedocs
 changedir = docs
 deps =
@@ -27,9 +27,9 @@ deps =
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
-[testenv:{py36,py37,py38,py39,py310}-doctest]
+[testenv:{py36,py37,py38,py39,py310,py311}-doctest]
 commands =
-    py36,py37,py38,py39,py310: pytest --doctest-modules --cov=petl petl
+    py36,py37,py38,py39,py310,py311: pytest --doctest-modules --cov=petl petl
 [testenv:{py36,py37,py38,py39}-dochtml]
 changedir = docs
 deps =


### PR DESCRIPTION
This PR has the objective of <describe here>

## Changes

1. Added `python3.11` to the tox configuration
2. Added a new job in the github actions for testing `petL` with `python3.11` 
3. 
## Checklist

Use this checklist to ensure the quality of pull requests that include new code and/or make changes to existing code.

* [ ] ~~Source Code rules apply:~~
  * [ ] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behavior
  * [ ] All changes are documented in docs/changes.rst
* [ ] ~~Versioning and history tracking rules apply:~~
  * [ ] Using atomic commits when possible
  * [ ] Commits are reversible when possible
  * [ ] There are no incomplete changes in the pull request
  * [ ] There is no accidental garbage added to the source code
* [X] Testing rules apply:
  * [X] Tested locally using `tox` / `pytest`
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [X] State of these changes is:
  * [ ] Just a proof of concept
  * [X] Work in progress / Further changes needed
  * [ ] Ready to review
  * [ ] Ready to merge
