### PR TITLE
Gh actions upgrade

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@main
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Publish the package version ${{ github.event.release.tag_name }} to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           print_hash: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@main
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -42,7 +42,7 @@ jobs:
           echo 'testing=full' >> $GITHUB_ENV
 
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Install linux tools
         if: matrix.os == 'ubuntu-latest'
@@ -144,7 +144,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -51,7 +51,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends python3-h5py
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@main
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 


### PR DESCRIPTION
This PR has the objective of upgrading deprecated versions of github actions.

## Changes

1. upgrade release to pypa/gh-action-pypi-publish@release/v1
2. upgrade to actions/setup-python@v4
3. upgrade to actions/checkout@main

## Checklist

Use this checklist to ensure the quality of pull requests that include new code and/or make changes to existing code.

* [X] Versioning and history tracking guidelines:
  * [X] Using atomic commits whenever possible
  * [X] Commits are reversible whenever possible
  * [ ] There are no incomplete changes in the pull request
  * [ ] There is no accidental garbage added to the source code
* [X] Testing guidelines:
  * [ ] Tested locally using `tox` / `pytest`
  * [X] Rebased to `master` branch and tested before sending the PR
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [X] State of these changes is:
  * [ ] Just a proof of concept
  * [X] Work in progress / Further changes needed
  * [ ] Ready to review
  * [ ] Ready to merge
