### PR TITLE
ci: workaround for actions/setup-python#672

### DIFF
--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -27,7 +27,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
-        python: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        include:
+          - python: '2.7'
+            os: "ubuntu-20.04"
+          - python: '2.7'
+            os: "macos-11"
+          - python: '2.7'
+            os: "windows-2019"
 
     runs-on: "${{ matrix.os }}"
 

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -27,16 +27,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
-        python: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        include:
+          - python: '2.7'
+            os: "ubuntu-latest"
+
     runs-on: "${{ matrix.os }}"
     env:
       testing: simple
+      python_eol: no
     steps:
       - name: Determine what scope of testing is available on ${{ matrix.os }}
         if: |
           (matrix.python >= '3.' ) && ( matrix.os != 'windows-latest' )
         run: |
           echo 'testing=full' >> $GITHUB_ENV
+
+      - name: Determine if the python ${{ matrix.python }} is available on ${{ matrix.os }}
+        if: |
+          (matrix.python < '3.' ) || ( matrix.python == '3.6' && matrix.os == 'ubuntu-latest' )
+        run: |
+          echo 'python_eol=yes' >> $GITHUB_ENV
 
       - name: Checkout source code
         uses: actions/checkout@main
@@ -48,13 +59,13 @@ jobs:
           sudo apt-get install -y --no-install-recommends python3-h5py
 
       - name: Set up Python ${{ matrix.python }}
-        if: matrix.python >= '3.'
+        if: env.python_eol == 'no'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Set up EOL Python ${{ matrix.python }}
-        if: matrix.python < '3.'
+      - name: Set up Python ${{ matrix.python }} discontinued on ${{ matrix.os }}
+        if: env.python_eol == 'yes'
         uses: MatteoH2O1999/setup-python@v1
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -27,20 +27,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
-        include:
-          - python: '2.7'
-            os: "ubuntu-20.04"
-          - python: '2.7'
-            os: "macos-11"
-          - python: '2.7'
-            os: "windows-2019"
-
+        python: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
     runs-on: "${{ matrix.os }}"
-
     env:
       testing: simple
-        
     steps:
       - name: Determine what scope of testing is available on ${{ matrix.os }}
         if: |
@@ -58,9 +48,17 @@ jobs:
           sudo apt-get install -y --no-install-recommends python3-h5py
 
       - name: Set up Python ${{ matrix.python }}
+        if: matrix.python >= '3.'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+
+      - name: Set up EOL Python ${{ matrix.python }}
+        if: matrix.python < '3.'
+        uses: MatteoH2O1999/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
 
       - name: Install test dependencies
         run: |


### PR DESCRIPTION
This PR has the objective of fixing actions/setup-python#672.

## Changes

1. python 2.7 not available on GitHub latest runners
2. python 3.6 not available on GitHub ubuntu-latest runner

## Checklist

Use this checklist to ensure the quality of pull requests that include new code and/or make changes to existing code.

* [ ] Source Code guidelines:
  * [ ] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behavior
  * [ ] All changes are documented in docs/changes.rst
* [ ] Versioning and history tracking guidelines:
  * [ ] Using atomic commits whenever possible
  * [ ] Commits are reversible whenever possible
  * [ ] There are no incomplete changes in the pull request
  * [ ] There is no accidental garbage added to the source code
* [ ] Testing guidelines:
  * [ ] Tested locally using `tox` / `pytest`
  * [ ] Rebased to `master` branch and tested before sending the PR
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [ ] Ready to review
  * [ ] Ready to merge
