### PR TITLE
ci: fix build as sqlalchemy is not supported yet

### DIFF
--- a/requirements-database.txt
+++ b/requirements-database.txt
@@ -2,6 +2,6 @@
 
 cryptography 
 pymysql 
-SQLAlchemy>=1.3.6
+SQLAlchemy>=1.3.6,<2.0
 psycopg2-binary
 # PyMySQL==0.9.3

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     extras_require={
         'avro': ['fastavro>=0.24.0'],
         'bcolz': ['bcolz>=1.2.1'],
-        'db': ['SQLAlchemy>=1.3.6'],
+        'db': ['SQLAlchemy>=1.3.6,<2.0'],
         'hdf5': ['cython>=0.29.13', 'numpy>=1.16.4', 'numexpr>=2.6.9', 
                  'tables>=3.5.2'],
         'http': ['aiohttp>=3.6.2', 'requests'],


### PR DESCRIPTION
This PR has the objective of restricting the maximum supported version of SQLAlchemy.

## Changes

1. Added in requirements-database.txt: SQLAlchemy>=1.3.6,<2.0
2. Added in setup.py: SQLAlchemy>=1.3.6,<2.0

For SQLAlchemy >=2.0 check #648.

## Checklist

Use this checklist to ensure the quality of pull requests that include new code and/or make changes to existing code.

* [ ] Source Code guidelines:
  * [ ] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behavior
  * [ ] All changes are documented in docs/changes.rst
* [x] Versioning and history tracking guidelines:
  * [x] Using atomic commits whenever possible
  * [x] Commits are reversible whenever possible
  * [ ] There are no incomplete changes in the pull request
  * [x] There is no accidental garbage added to the source code
* [X] Testing guidelines:
  * [X] Tested locally using `tox` / `pytest`
  * [X] Rebased to `master` branch and tested before sending the PR
  * [x] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [x] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [X] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [X] Ready to review
  * [X] Ready to merge
