### PR TITLE
Resolve DeprecationWarning: Seeding based on hashing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,9 @@ Version 1.7.15
 * Add unit tests for randomtable, dummytable, and their supporting functions and classes.
   By :user:`bmos`, :issue:`657`.
 
+* Fix: DeprecationWarning: Seeding based on hashing is deprecated since Python 3.9 and will be removed in a subsequent version.
+  By :user:`bmos`, :issue:`657`.
+
 Version 1.7.14
 --------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 1.7.15
+--------------
+
+* Add unit tests for randomtable, dummytable, and their supporting functions and classes.
+  By :user:`bmos`, :issue:`657`.
+
 Version 1.7.14
 --------------
 

--- a/petl/test/util/test_random.py
+++ b/petl/test/util/test_random.py
@@ -1,0 +1,79 @@
+import random
+from functools import partial
+
+from petl.util.random import randomtable, RandomTable, dummytable, DummyTable
+
+
+def test_randomtable():
+    """
+    Ensure that randomtable provides a table with the right number of rows and columns.
+    """
+    columns, rows = 3, 10
+    table = randomtable(columns, rows)
+
+    assert len(table[0]) == columns
+    assert len(table) == rows + 1
+
+
+def test_randomtable_class():
+    """
+    Ensure that RandomTable provides a table with the right number of rows and columns.
+    """
+    columns, rows = 4, 60
+    table = RandomTable(numflds=columns, numrows=rows)
+
+    assert len(table[0]) == columns
+    assert len(table) == rows + 1
+
+
+def test_dummytable_custom_fields():
+    """
+    Ensure that dummytable provides a table with the right number of rows
+    and that it accepts and uses custom column names provided.
+    """
+    columns = (
+        ('count', partial(random.randint, 0, 100)),
+        ('pet', partial(random.choice, ('dog', 'cat', 'cow'))),
+        ('color', partial(random.choice, ('yellow', 'orange', 'brown'))),
+        ('value', random.random)
+    )
+    rows = 35
+
+    table = dummytable(numrows=rows, fields=columns)
+    assert table[0] == ('count', 'pet', 'color', 'value')
+    assert len(table) == rows + 1
+
+
+def test_dummytable_no_seed():
+    """
+    Ensure that dummytable provides a table with the right number of rows
+    and columns when not provided with a seed.
+    """
+    rows = 35
+
+    table = dummytable(numrows=rows)
+    assert len(table[0]) == 3
+    assert len(table) == rows + 1
+
+
+def test_dummytable_int_seed():
+    """
+    Ensure that dummytable provides a table with the right number of rows
+    and columns when provided with an integer as a seed.
+    """
+    rows = 35
+    seed = 42
+    table = dummytable(numrows=rows, seed=seed)
+    assert len(table[0]) == 3
+    assert len(table) == rows + 1
+
+
+def test_dummytable_class():
+    """
+    Ensure that DummyTable provides a table with the right number of rows
+    and columns.
+    """
+    rows = 70
+    table = DummyTable(numrows=rows)
+
+    assert len(table) == rows + 1

--- a/petl/test/util/test_random.py
+++ b/petl/test/util/test_random.py
@@ -1,7 +1,21 @@
 import random
+import time
 from functools import partial
 
-from petl.util.random import randomtable, RandomTable, dummytable, DummyTable
+from petl.util.random import randomseed, randomtable, RandomTable, dummytable, DummyTable
+
+
+def test_randomseed():
+    """
+    Ensure that randomseed provides a non-empty string that changes.
+    """
+    seed_1 = randomseed()
+    time.sleep(1)
+    seed_2 = randomseed()
+
+    assert isinstance(seed_1, str)
+    assert seed_1 != ""
+    assert seed_1 != seed_2
 
 
 def test_randomtable():

--- a/petl/test/util/test_random.py
+++ b/petl/test/util/test_random.py
@@ -1,4 +1,4 @@
-import random
+import random as pyrandom
 import time
 from functools import partial
 
@@ -46,10 +46,10 @@ def test_dummytable_custom_fields():
     and that it accepts and uses custom column names provided.
     """
     columns = (
-        ('count', partial(random.randint, 0, 100)),
-        ('pet', partial(random.choice, ('dog', 'cat', 'cow'))),
-        ('color', partial(random.choice, ('yellow', 'orange', 'brown'))),
-        ('value', random.random)
+        ('count', partial(pyrandom.randint, 0, 100)),
+        ('pet', partial(pyrandom.choice, ['dog', 'cat', 'cow', ])),
+        ('color', partial(pyrandom.choice, ['yellow', 'orange', 'brown'])),
+        ('value', pyrandom.random),
     )
     rows = 35
 

--- a/petl/util/random.py
+++ b/petl/util/random.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, division
 
 import hashlib
-import random
+import random as pyrandom
 import time
 from collections import OrderedDict
 from functools import partial
@@ -57,7 +57,6 @@ def randomtable(numflds=5, numrows=100, wait=0, seed=None):
 
 
 class RandomTable(Table):
-
     def __init__(self, numflds=5, numrows=100, wait=0, seed=None):
         self.numflds = numflds
         self.numrows = numrows
@@ -68,16 +67,15 @@ class RandomTable(Table):
             self.seed = seed
 
     def __iter__(self):
-
         nf = self.numflds
         nr = self.numrows
         seed = self.seed
 
         # N.B., we want this to be stable, i.e., same data each time
-        random.seed(seed)
+        pyrandom.seed(seed)
 
         # construct fields
-        flds = ['f%s' % n for n in range(nf)]
+        flds = ["f%s" % n for n in range(nf)]
         yield tuple(flds)
 
         # construct data rows
@@ -85,18 +83,22 @@ class RandomTable(Table):
             # artificial delay
             if self.wait:
                 time.sleep(self.wait)
-            yield tuple(random.random() for n in range(nf))
+            yield tuple(pyrandom.random() for n in range(nf))
 
     def reseed(self):
         self.seed = randomseed()
 
 
-def dummytable(numrows=100,
-               fields=(('foo', partial(random.randint, 0, 100)),
-                       ('bar', partial(random.choice, ('apples', 'pears',
-                                                       'bananas', 'oranges'))),
-                       ('baz', random.random)),
-               wait=0, seed=None):
+def dummytable(
+        numrows=100,
+        fields=(
+                ('foo', partial(pyrandom.randint, 0, 100)),
+                ('bar', partial(pyrandom.choice, ('apples', 'pears', 'bananas', 'oranges'))),
+                ('baz', pyrandom.random),
+        ),
+        wait=0,
+        seed=None,
+):
     """
     Construct a table with dummy data. Use `numrows` to specify the number of
     rows. Set `wait` to a float greater than zero to simulate a delay on each
@@ -121,13 +123,11 @@ def dummytable(numrows=100,
         ...
         <BLANKLINE>
 
-        >>> # customise fields
-        ... import random
+        >>> import random as pyrandom
         >>> from functools import partial
-        >>> fields = [('foo', random.random),
-        ...           ('bar', partial(random.randint, 0, 500)),
-        ...           ('baz', partial(random.choice,
-        ...                           ['chocolate', 'strawberry', 'vanilla']))]
+        >>> fields = [('foo', pyrandom.random),
+        ...           ('bar', partial(pyrandom.randint, 0, 500)),
+        ...           ('baz', partial(pyrandom.choice, ['chocolate', 'strawberry', 'vanilla']))]
         >>> table2 = etl.dummytable(100, fields=fields, seed=42)
         >>> table2
         +---------------------+-----+-------------+
@@ -164,7 +164,6 @@ def dummytable(numrows=100,
 
 
 class DummyTable(Table):
-
     def __init__(self, numrows=100, fields=None, wait=0, seed=None):
         self.numrows = numrows
         self.wait = wait
@@ -186,7 +185,7 @@ class DummyTable(Table):
         fields = self.fields.copy()
 
         # N.B., we want this to be stable, i.e., same data each time
-        random.seed(seed)
+        pyrandom.seed(seed)
 
         # construct header row
         hdr = tuple(text_type(f) for f in fields.keys())

--- a/petl/util/random.py
+++ b/petl/util/random.py
@@ -1,15 +1,24 @@
 from __future__ import absolute_import, print_function, division
 
-
-import datetime
+import hashlib
 import random
 import time
 from collections import OrderedDict
 from functools import partial
+
 from petl.compat import xrange, text_type
-
-
 from petl.util.base import Table
+
+
+def randomseed():
+    """
+    Obtain the hex digest of a sha256 hash of the
+    current epoch time in nanoseconds.
+    """
+
+    time_ns = str(time.time()).encode()
+    hash_time = hashlib.sha256(time_ns).hexdigest()
+    return hash_time
 
 
 def randomtable(numflds=5, numrows=100, wait=0, seed=None):
@@ -36,9 +45,11 @@ def randomtable(numflds=5, numrows=100, wait=0, seed=None):
         | 0.026535969683863625 |   0.1988376506866485 |  0.6498844377795232 |
         +----------------------+----------------------+---------------------+
         ...
+        <BLANKLINE>
 
     Note that the data are generated on the fly and are not stored in memory,
     so this function can be used to simulate very large tables.
+    The only supported seed types are: None, int, float, str, bytes, and bytearray.
 
     """
 
@@ -52,7 +63,7 @@ class RandomTable(Table):
         self.numrows = numrows
         self.wait = wait
         if seed is None:
-            self.seed = datetime.datetime.now()
+            self.seed = randomseed()
         else:
             self.seed = seed
 
@@ -77,7 +88,7 @@ class RandomTable(Table):
             yield tuple(random.random() for n in range(nf))
 
     def reseed(self):
-        self.seed = datetime.datetime.now()
+        self.seed = randomseed()
 
 
 def dummytable(numrows=100,
@@ -108,6 +119,7 @@ def dummytable(numrows=100,
         |   4 | 'apples' |  0.09369523986159245 |
         +-----+----------+----------------------+
         ...
+        <BLANKLINE>
 
         >>> # customise fields
         ... import random
@@ -132,12 +144,19 @@ def dummytable(numrows=100,
         |  0.4219218196852704 |  15 | 'chocolate' |
         +---------------------+-----+-------------+
         ...
+        <BLANKLINE>
+
+        >>> table3_1 = etl.dummytable(50)
+        >>> table3_2 = etl.dummytable(100)
+        >>> table3_1[5] == table3_2[5]
+        False
 
     Data generation functions can be specified via the `fields` keyword
     argument.
 
     Note that the data are generated on the fly and are not stored in memory,
     so this function can be used to simulate very large tables.
+    The only supported seed types are: None, int, float, str, bytes, and bytearray.
 
     """
 
@@ -154,7 +173,7 @@ class DummyTable(Table):
         else:
             self.fields = OrderedDict(fields)
         if seed is None:
-            self.seed = datetime.datetime.now()
+            self.seed = randomseed()
         else:
             self.seed = seed
 
@@ -181,4 +200,4 @@ class DummyTable(Table):
             yield tuple(fields[f]() for f in fields)
 
     def reseed(self):
-        self.seed = datetime.datetime.now()
+        self.seed = randomseed()


### PR DESCRIPTION
When calling randomtable without providing a seed, the warning `DeprecationWarning: Seeding based on hashing is deprecated since Python 3.9 and will be removed in a subsequent version. The only supported seed types are: None, int, float, str, bytes, and bytearray.` is emitted.

This actually becomes a TypeError in 3.11 and 3.12.

closes #657

It also seems like we don't even need to provide a seed based on the documentation, but I stuck to the way it was implemented before (using a hashed version of the date).
2.7: https://docs.python.org/2.7/library/random.html#random.seed
3.12: https://docs.python.org/3.12/library/random.html#random.seed

I also noticed that the filename utils/random.py seems to be conflicting with python's random module. When debugging the doctests in that file, I had to rename it.

## Changes

* Add unit tests for randomtable, dummytable, and their supporting functions and classes and updated their doctests to pass.
* Fix: DeprecationWarning: Seeding based on hashing is deprecated since Python 3.9 and will be removed in a subsequent version.

## Checklist

Use this checklist to ensure the quality of pull requests that include new code and/or make changes to existing code.

* [x] Source Code guidelines:
  * [x] Includes unit tests
  * [x] New functions have docstrings with examples that can be run with doctest
  * [x] New functions are included in API docs
  * [x] Docstrings include notes for any changes to API or behavior
  * [x] All changes are documented in docs/changes.rst
* [x] Versioning and history tracking guidelines:
  * [x] Using atomic commits whenever possible
  * [x] Commits are reversible whenever possible
  * [x] There are no incomplete changes in the pull request
  * [x] There is no accidental garbage added to the source code
* [x] Testing guidelines:
  * [x] Tested locally using `tox` / `pytest`
  * [x] Rebased to `master` branch and tested before sending the PR
  * [x] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [x] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [x] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [x] Ready to review
  * [x] Ready to merge
