### PR TITLE
ci: only trigger actions for code analysis workflows after testing changes

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -23,7 +23,6 @@ on:
   #   branches: [ "master" ]
   workflow_run:
     workflows: [Test Changes]
-    branches: [ "master" ]
     types:
       - completed
   workflow_dispatch:

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -27,6 +27,16 @@ on:
     types:
       - completed
   workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+        - info
+        - warning
+        - debug
 
 permissions:
   contents: read

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -26,6 +26,7 @@ on:
     branches: [ "master" ]
     types:
       - completed
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -16,8 +16,8 @@ name: Codacy Security Scan
 on:
   schedule:
     - cron: '59 11 27 * *'
-  push:
-    branches: [ "master" ]
+  # push:
+  #   branches: [ "master" ]
   # pull_request:
   #   # The branches below must be a subset of the branches above
   #   branches: [ "master" ]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,6 @@ on:
   #   branches: [ "master" ]
   workflow_run:
     workflows: [Test Changes]
-    branches: [ "master" ]
     types:
       - completed
   workflow_dispatch:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,16 @@ on:
     types:
       - completed
   workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+        - info
+        - warning
+        - debug
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,7 @@ on:
     branches: [ "master" ]
     types:
       - completed
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,8 +14,8 @@ name: "CodeQL"
 on:
   schedule:
     - cron: '59 10 27 * *'
-  push:
-    branches: [ "master" ]
+  # push:
+  #   branches: [ "master" ]
   # pull_request:
   #   branches: [ "master" ]
   workflow_run:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,6 +3,17 @@ name: release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+        - info
+        - warning
+        - debug
 
 jobs:
   pypi:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,6 +17,9 @@ on:
 
 jobs:
   pypi:
+    strategy:
+      matrix:
+        python: ['3.10']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -19,14 +19,14 @@ on:
         - info
         - warning
         - debug
-      tags:
-        description: 'Test scenario tags'
-        required: false
-        type: boolean
-      environment:
-        description: 'Environment to run tests against'
-        type: environment
-        required: true
+      # tags:
+      #   description: 'Test scenario tags'
+      #   required: false
+      #   type: boolean
+      # environment:
+      #   description: 'Environment to run tests against'
+      #   type: environment
+      #   required: true
 
 jobs:
   run-guard:

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, labeled]
+    types: [opened, reopened, synchronize, ready_for_review]  # labeled
   workflow_dispatch:
     inputs:
       logLevel:

--- a/requirements-formats.txt
+++ b/requirements-formats.txt
@@ -13,4 +13,5 @@ fastavro==0.24.2 ; python_version < '3.0'
 gspread>=3.4.0 ; python_version >= '3.4'
 
 # version 3.9.2 fails with python3.12 on macos-latest: PyTables/PyTables#1093
-tables ; python_version <= '3.10'
+tables ; sys_platform != 'darwin'
+

--- a/requirements-formats.txt
+++ b/requirements-formats.txt
@@ -13,4 +13,4 @@ fastavro==0.24.2 ; python_version < '3.0'
 gspread>=3.4.0 ; python_version >= '3.4'
 
 # version 3.9.2 fails with python3.12 on macos-latest: PyTables/PyTables#1093
-tables ; python_version != '3.12'
+tables ; python_version <= '3.10'


### PR DESCRIPTION
This PR has the objective of avoiding double triggering of workflows

## Changes

1. only trigger actions for code analysis workflows after testing changes
2. allow manual triggering of code analysis workflows

## Checklist

Use this checklist to ensure the quality of pull requests that include new code and/or make changes to existing code.

* [ ] Source Code guidelines:
  * [ ] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behavior
  * [ ] All changes are documented in docs/changes.rst
* [X] Versioning and history tracking guidelines:
  * [X] Using atomic commits whenever possible
  * [X] Commits are reversible whenever possible
  * [X] There are no incomplete changes in the pull request
  * [X] There is no accidental garbage added to the source code
* [X] Testing guidelines:
  * [X] Tested locally using `tox` / `pytest`
  * [X] Rebased to the `master` branch and tested before sending the PR
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [
* [X] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [X] Ready to review
  * [X] Ready to merge
