### PR TITLE
Fix fromjson() to support reading from stdin

### DIFF
--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --prefer-binary -r requirements-tests.txt
+          python -m pip install -e .
 
       - name: Setup environment variables for remote filesystem testing
         if: matrix.os == 'ubuntu-latest' && matrix.python == '3.8'

--- a/petl/io/json.py
+++ b/petl/io/json.py
@@ -16,7 +16,7 @@ from petl.io.sources import read_source_from_arg, write_source_from_arg
 from petl.util.base import data, Table, dicts as _dicts, iterpeek
 
 
-def fromjson(source, *args, **kwargs):
+def fromjson(source=None, *args, **kwargs):
     """
     Extract data from a JSON file. The file must contain a JSON array as
     the top level object, and each member of the array will be treated as a

--- a/petl/test/test_executable.py
+++ b/petl/test/test_executable.py
@@ -3,8 +3,20 @@ from __future__ import print_function, division, absolute_import
 import subprocess
 
 def test_executable():
-    result = subprocess.run("""
+    result = subprocess.check_output("""
         (echo foo,bar ; echo a,b; echo c,d) |
         petl 'fromcsv().cut("foo").head(1).tocsv()'
-    """, shell=True, check=True, capture_output=True)
-    assert result.stdout == b'foo\r\na\r\n'
+    """, shell=True)
+    assert result == b'foo\r\na\r\n'
+
+def test_json_stdin():
+    result = subprocess.check_output("""
+        echo '[{"foo": "a", "bar": "b"}]' |
+        petl 'fromjson().tocsv()'
+    """, shell=True)
+    assert result == b'foo,bar\r\na,b\r\n'
+    result = subprocess.check_output("""
+        ( echo '{"foo": "a", "bar": "b"}' ; echo '{"foo": "c", "bar": "d"}' ) |
+        petl 'fromjson(lines=True).tocsv()'
+    """, shell=True)
+    assert result == b'foo,bar\r\na,b\r\nc,d\r\n'

--- a/petl/test/test_executable.py
+++ b/petl/test/test_executable.py
@@ -1,0 +1,10 @@
+from __future__ import print_function, division, absolute_import
+
+import subprocess
+
+def test_executable():
+    result = subprocess.run("""
+        (echo foo,bar ; echo a,b; echo c,d) |
+        petl 'fromcsv().cut("foo").head(1).tocsv()'
+    """, shell=True, check=True, capture_output=True)
+    assert result.stdout == b'foo\r\na\r\n'


### PR DESCRIPTION
Trivial PR to support reading from stdin (`source=None`) in `fromjson()`.

Two things you may want me to do before merging -

1. I didn't add tests because there are no tests I could find for the use of `source=None` in any `io` module (e.g., also not in `csv` etc). Generally, perhaps I missed them but I didn't see tests that fork/exec the `bin/petl` executable at all...?
2. Add `source=None` to other modules. I ran `git grep 'def from' | grep source | grep -v source=None` and found a few more that miss it, let me know if you'd like me to add it to any/all of them.
    Modules which appear to be missing `source=None`: `avro`, `bcolz`, `pytables` (maybe), `xml`


## Checklist

Use this checklist to ensure the quality of pull requests that include new code and/or make changes to existing code.

* [ ] Source Code guidelines:
  * [ ] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behavior
  * [ ] All changes are documented in docs/changes.rst
* [ ] Versioning and history tracking guidelines:
  * [ ] Using atomic commits whenever possible
  * [ ] Commits are reversible whenever possible
  * [ ] There are no incomplete changes in the pull request
  * [ ] There is no accidental garbage added to the source code
* [ ] Testing guidelines:
  * [ ] Tested locally using `tox` / `pytest`
  * [ ] Rebased to `master` branch and tested before sending the PR
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [ ] Ready to review
  * [ ] Ready to merge
