### PR TITLE
Fix: Joining tables with uneven rows gives wrong result.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 1.7.16
+--------------
+
+* Fix: Joining tables with uneven rows gives wrong result.
+  By :user:`MichalKarol`.
+
 Version 1.7.15
 --------------
 


### PR DESCRIPTION
This PR has the objective of the bug in joins and hashjoins when tables with uneven rows were joined, data was put in incorrect columns. Issue is similar to the one reported here #176.

## Changes
* Added `stack` to square up tables before join.  

## Checklist

Use this checklist to ensure the quality of pull requests that include new code and/or make changes to existing code.

* [x] Source Code guidelines:
  * [x] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [x] Docstrings include notes for any changes to API or behavior
  * [x] All changes are documented in docs/changes.rst
* [x] Versioning and history tracking guidelines:
  * [x] Using atomic commits whenever possible
  * [x] Commits are reversible whenever possible
  * [x] There are no incomplete changes in the pull request
  * [x] There is no accidental garbage added to the source code
* [x] Testing guidelines:
  * [x] Tested locally using `tox` / `pytest`
  * [x] Rebased to `master` branch and tested before sending the PR
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [x] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [x] Ready to review
  * [ ] Ready to merge
