### PR TITLE
Upgrade Python versions supported by setup-python and runner-images on Github Actions

### DIFF
--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -77,6 +77,9 @@ jobs:
             python: '3.6'
           - os: 'macos-latest'
             python: '3.7'
+          # python 3.7 too slow on ubuntu-latest
+          - os: 'ubuntu-latest'
+            python: '3.7'
 
     runs-on: "${{ matrix.os }}"
     steps:

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -47,7 +47,7 @@ jobs:
         os: [ "ubuntu-latest", "windows-latest", "macos-latest", "macos-13" ]
         #@ https://github.com/marketplace/actions/setup-python
         #@ https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#python
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         # TODO: Also test with PyPy and GraalPy @https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#graalpy
         include:
           # Default configuration for all jobs

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -41,8 +41,12 @@ jobs:
     needs: run-guard
     strategy:
       fail-fast: false
+      # TODO: Also test on arm64, with PyPy and GraalPy @https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#graalpy
       matrix:
+        #@ https://github.com/actions/runner-images#available-images
         os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
+        #@ https://github.com/marketplace/actions/setup-python
+        #@ https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#python
         python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           - python: '2.7'

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -43,7 +43,8 @@ jobs:
       fail-fast: false
       matrix:
         #@ https://github.com/actions/runner-images#available-images
-        os: [ "ubuntu-latest", "windows-latest", "macos-latest", "macos-latest-large" ]
+        #@ https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        os: [ "ubuntu-latest", "windows-latest", "macos-latest", "macos-13" ]
         #@ https://github.com/marketplace/actions/setup-python
         #@ https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#python
         python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
@@ -67,6 +68,7 @@ jobs:
             install: 'yes'
         exclude:
           # macos-latest == macOS-14-arm64
+          # macos-13 == Intel
           - os: 'macos-latest'
             python: '3.6'
           - os: 'macos-latest'

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -49,25 +49,25 @@ jobs:
         #@ https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#python
         python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         include:
+          # Default configuration for all jobs
+          - mode: 'full'
+          - install: 'no'
+          - primary: '3.8'
+          # Conditional configuration overrides
+          - python: '3.6'
+            install: 'yes'
+          - python: '3.7'
+            install: 'yes'
+          - os: 'windows-latest'
+            mode: 'basic'
+          # Additional Jobs not included in the matrix above
           - python: '2.7'
             os: "ubuntu-latest"
+            mode: 'basic'
+            install: 'yes'
 
     runs-on: "${{ matrix.os }}"
-    env:
-      testing: simple
-      python_eol: no
     steps:
-      - name: Determine what scope of testing is available on ${{ matrix.os }}
-        if: |
-          (matrix.python >= '3.' ) && ( matrix.os != 'windows-latest' )
-        run: |
-          echo 'testing=full' >> $GITHUB_ENV
-
-      - name: Determine if the python ${{ matrix.python }} is available on ${{ matrix.os }}
-        if: |
-          (matrix.python < '3.' ) || ( matrix.python == '3.6' && matrix.os == 'ubuntu-latest' )
-        run: |
-          echo 'python_eol=yes' >> $GITHUB_ENV
 
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -78,14 +78,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends python3-h5py
 
-      - name: Set up Python ${{ matrix.python }}
-        if: env.python_eol == 'no'
+      - name: Set up Python ${{ matrix.python }} with install = ${{ matrix.install }}
+        if: matrix.install == 'no'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
       - name: Set up Python ${{ matrix.python }} discontinued on ${{ matrix.os }}
-        if: env.python_eol == 'yes'
+        if: matrix.install == 'yes'
         uses: MatteoH2O1999/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
@@ -96,8 +96,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --prefer-binary -r requirements-tests.txt
 
-      - name: Setup environment variables for remote filesystem testing
-        if: matrix.os == 'ubuntu-latest' && matrix.python == '3.8'
+      - name: Setup environment variables for remote filesystem testing with primary = ${{ matrix.primary }}
+        if: matrix.os == 'ubuntu-latest' && matrix.python == matrix.primary
         run: |
           echo "Setup SMB environment variable to trigger testing in Petl"
           echo 'PETL_TEST_SMB=smb://WORKGROUP;petl:test@localhost/public/' >> $GITHUB_ENV
@@ -107,8 +107,8 @@ jobs:
           python -m pip install --prefer-binary -r requirements-remote.txt
           echo "::endgroup::"
 
-      - name: Install optional test dependencies for mode ${{ env.testing }}
-        if: matrix.os == 'ubuntu-latest' && matrix.python >= '3.7'
+      - name: Install optional test dependencies with install = ${{ matrix.install }}
+        if: matrix.os == 'ubuntu-latest' && matrix.install == 'no'
         env:
           DISABLE_BLOSC_AVX2: 1
         run: |
@@ -120,8 +120,8 @@ jobs:
           # pip install --prefer-binary bcolz
           echo "::endgroup::"
 
-      - name: Install containers for remote filesystem testing
-        if: matrix.os == 'ubuntu-latest' && matrix.python == '3.8'
+      - name: Install containers for remote filesystem testing with install = ${{ matrix.install }}
+        if: matrix.os == 'ubuntu-latest' && matrix.install == 'no'
         run: |
           echo "::group::Setup docker for SMB at: ${{ env.PETL_TEST_SMB }}$"
           docker run -it --name samba -p 139:139 -p 445:445 -d "dperson/samba" -p -u "petl;test" -s "public;/public-dir;yes;no;yes;all"
@@ -130,8 +130,8 @@ jobs:
           docker run -it --name sftp -p 2244:22 -d atmoz/sftp petl:test:::public
           echo "::endgroup::"
 
-      - name: Install containers for remote database testing
-        if: matrix.os == 'ubuntu-latest' && matrix.python >= '3.6'
+      - name: Install containers for remote database testing for mode ${{ matrix.mode }}
+        if: matrix.os == 'ubuntu-latest' && matrix.mode == 'full'
         run: |
           echo "::group::Setup docker for MySQL"
           docker run -it --name mysql -p 3306:3306 -p 33060:33060 -e MYSQL_ROOT_PASSWORD=pass0 -e MYSQL_DATABASE=petl -e MYSQL_USER=petl -e MYSQL_PASSWORD=test -d mysql:latest
@@ -143,11 +143,11 @@ jobs:
           python -m pip install --prefer-binary -r requirements-database.txt
           echo "::endgroup::"
 
-      - name: Setup petl package
+      - name: Setup petl package for mode ${{ matrix.mode }}
         run: python setup.py sdist bdist_wheel
 
       - name: Install extra packages dependencies for mode full
-        if: env.testing == 'full'
+        if: matrix.mode == 'full'
         run: python -m pip install --prefer-binary -r requirements-formats.txt
 
       - name: List Installed Packages for Throubleshooting
@@ -157,18 +157,18 @@ jobs:
           echo "::endgroup::"
 
       - name: Test python source code for mode simple
-        if: env.testing == 'simple'
+        if: matrix.mode == 'simple'
         run: pytest --cov=petl petl
 
       - name: Test documentation inside source code for mode full
-        if: env.testing == 'full'
+        if: matrix.mode == 'full'
         run: |
           echo "::group::Perform doctest-modules execution with coverage"
           pytest --doctest-modules --cov=petl petl
           echo "::endgroup::"
 
-      - name: Coveralls
-        if: matrix.os == 'ubuntu-latest' && matrix.python == '3.8'
+      - name: Coveralls with primary = ${{ matrix.primary }}
+        if: matrix.os == 'ubuntu-latest' && matrix.python == matrix.primary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -66,9 +66,9 @@ jobs:
             mode: 'basic'
             install: 'yes'
         exclude:
+          # macos-latest == macOS-14-arm64
           - os: 'macos-latest'
             install: 'yes'
-            # macos-latest == macOS-14-arm64
 
     runs-on: "${{ matrix.os }}"
     steps:

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -61,9 +61,13 @@ jobs:
             install: 'yes'
           - os: 'windows-latest'
             mode: 'basic'
+          # Handle random test failures
+          - os: 'ubuntu-latest'
+            python: '3.9'
+            mode: 'basic'
           # Additional Jobs not included in the matrix above
           - python: '2.7'
-            os: "ubuntu-latest"
+            os: 'ubuntu-latest'
             mode: 'basic'
             install: 'yes'
         exclude:

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -44,7 +44,7 @@ jobs:
       # TODO: Also test on arm64, with PyPy and GraalPy @https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#graalpy
       matrix:
         #@ https://github.com/actions/runner-images#available-images
-        os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
+        os: [ "ubuntu-latest", "windows-latest", "macos-latest", "macos-latest-large" ]
         #@ https://github.com/marketplace/actions/setup-python
         #@ https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#python
         python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
@@ -65,6 +65,10 @@ jobs:
             os: "ubuntu-latest"
             mode: 'basic'
             install: 'yes'
+        exclude:
+          - os: 'macos-latest'
+            install: 'yes'
+            # macos-latest == macOS-14-arm64
 
     runs-on: "${{ matrix.os }}"
     steps:

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -41,13 +41,13 @@ jobs:
     needs: run-guard
     strategy:
       fail-fast: false
-      # TODO: Also test on arm64, with PyPy and GraalPy @https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#graalpy
       matrix:
         #@ https://github.com/actions/runner-images#available-images
         os: [ "ubuntu-latest", "windows-latest", "macos-latest", "macos-latest-large" ]
         #@ https://github.com/marketplace/actions/setup-python
         #@ https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#python
         python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        # TODO: Also test with PyPy and GraalPy @https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#graalpy
         include:
           # Default configuration for all jobs
           - mode: 'full'
@@ -68,7 +68,9 @@ jobs:
         exclude:
           # macos-latest == macOS-14-arm64
           - os: 'macos-latest'
-            install: 'yes'
+            python: '3.6'
+          - os: 'macos-latest'
+            python: '3.7'
 
     runs-on: "${{ matrix.os }}"
     steps:

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -130,7 +130,7 @@ jobs:
           docker run -it --name sftp -p 2244:22 -d atmoz/sftp petl:test:::public
           echo "::endgroup::"
 
-      - name: Install containers for remote database testing for mode ${{ matrix.mode }}
+      - name: Install containers for remote database testing with mode = ${{ matrix.mode }}
         if: matrix.os == 'ubuntu-latest' && matrix.mode == 'full'
         run: |
           echo "::group::Setup docker for MySQL"
@@ -143,7 +143,7 @@ jobs:
           python -m pip install --prefer-binary -r requirements-database.txt
           echo "::endgroup::"
 
-      - name: Setup petl package for mode ${{ matrix.mode }}
+      - name: Setup petl package with mode = ${{ matrix.mode }}
         run: python setup.py sdist bdist_wheel
 
       - name: Install extra packages dependencies for mode full
@@ -156,8 +156,8 @@ jobs:
           python -m pip list --format freeze
           echo "::endgroup::"
 
-      - name: Test python source code for mode simple
-        if: matrix.mode == 'simple'
+      - name: Test python source code for mode basic
+        if: matrix.mode == 'basic'
         run: pytest --cov=petl petl
 
       - name: Test documentation inside source code for mode full
@@ -175,7 +175,7 @@ jobs:
           python -m pip install --upgrade coveralls
           coveralls --service=github
 
-      - name: Print source code coverage
+      - name: Print source code coverage with mode = ${{ matrix.mode }}
         run: coverage report -m
 
   test-documentation:

--- a/examples/util/lookups.py
+++ b/examples/util/lookups.py
@@ -1,10 +1,9 @@
-from __future__ import division, print_function, absolute_import
-
+from __future__ import absolute_import, division, print_function
 
 # lookup()
 ##########
-
 import petl as etl
+
 table1 = [['foo', 'bar'], 
           ['a', 1], 
           ['b', 2], 
@@ -31,10 +30,11 @@ lkp[('b', 3)]
 # object, including persistent dictionaries created via the 
 # shelve module
 import shelve
-lkp = shelve.open('example.dat', flag='n')
+
+lkp = shelve.open('example1.dat', flag='n')
 lkp = etl.lookup(table1, 'foo', 'bar', lkp)
 lkp.close()
-lkp = shelve.open('example.dat', flag='r')
+lkp = shelve.open('example1.dat', flag='r')
 lkp['a']
 lkp['b']
 
@@ -43,6 +43,7 @@ lkp['b']
 #############
 
 import petl as etl
+
 table1 = [['foo', 'bar'], 
           ['a', 1], 
           ['b', 2], 
@@ -73,10 +74,11 @@ lkp[('b', 3)]
 # object, including persistent dictionaries created via the 
 # shelve module
 import shelve
-lkp = shelve.open('example.dat', flag='n')
+
+lkp = shelve.open('example2.dat', flag='n')
 lkp = etl.lookupone(table1, 'foo', 'bar', lkp)
 lkp.close()
-lkp = shelve.open('example.dat', flag='r')
+lkp = shelve.open('example2.dat', flag='r')
 lkp['a']
 lkp['b']
 
@@ -85,6 +87,7 @@ lkp['b']
 ##############
 
 import petl as etl
+
 table1 = [['foo', 'bar'], 
           ['a', 1], 
           ['b', 2], 
@@ -106,10 +109,11 @@ lkp[('b', 3)]
 # object, including persistent dictionaries created via the 
 # shelve module
 import shelve
-lkp = shelve.open('example.dat', flag='n')
+
+lkp = shelve.open('example3.dat', flag='n')
 lkp = etl.dictlookup(table1, 'foo', lkp)
 lkp.close()
-lkp = shelve.open('example.dat', flag='r')
+lkp = shelve.open('example3.dat', flag='r')
 lkp['a']
 lkp['b']
 
@@ -118,6 +122,7 @@ lkp['b']
 #################
 
 import petl as etl
+
 table1 = [['foo', 'bar'],
           ['a', 1],
           ['b', 2],
@@ -148,10 +153,11 @@ lkp[('b', 3)]
 # object, including persistent dictionaries created via the
 # shelve module
 import shelve
-lkp = shelve.open('example.dat', flag='n')
+
+lkp = shelve.open('example4.dat', flag='n')
 lkp = etl.dictlookupone(table1, 'foo', lkp)
 lkp.close()
-lkp = shelve.open('example.dat', flag='r')
+lkp = shelve.open('example4.dat', flag='r')
 lkp['a']
 lkp['b']
 

--- a/petl/io/numpy.py
+++ b/petl/io/numpy.py
@@ -67,12 +67,12 @@ def toarray(table, dtype=None, count=-1, sample=1000):
         array([('apples', 1, 2.5), ('oranges', 3, 4.4), ('pears', 7, 0.1)],
               dtype=(numpy.record, [('foo', '<U7'), ('bar', '<i8'), ('baz', '<f8')]))
         >>> # the dtype can be specified as a string
-        ... a = etl.toarray(table, dtype='a4, i2, f4')
+        ... a = etl.toarray(table, dtype='S4, i2, f4')
         >>> a
         array([(b'appl', 1, 2.5), (b'oran', 3, 4.4), (b'pear', 7, 0.1)],
               dtype=[('foo', 'S4'), ('bar', '<i2'), ('baz', '<f4')])
         >>> # the dtype can also be partially specified
-        ... a = etl.toarray(table, dtype={'foo': 'a4'})
+        ... a = etl.toarray(table, dtype={'foo': 'S4'})
         >>> a
         array([(b'appl', 1, 2.5), (b'oran', 3, 4.4), (b'pear', 7, 0.1)],
               dtype=[('foo', 'S4'), ('bar', '<i8'), ('baz', '<f8')])
@@ -122,9 +122,9 @@ def fromarray(a):
         >>> a = np.array([('apples', 1, 2.5),
         ...               ('oranges', 3, 4.4),
         ...               ('pears', 7, 0.1)],
-        ...              dtype='U8, i4,f4')
+        ...              dtype='S8, i4, f4')
         >>> table = etl.fromarray(a)
-        >>> table
+        >>> table # doctest: +SKIP
         +-----------+----+-----+
         | f0        | f1 | f2  |
         +===========+====+=====+

--- a/petl/test/io/test_xml.py
+++ b/petl/test/io/test_xml.py
@@ -356,7 +356,7 @@ def test_toxml00():
 def test_toxml01():
     _check_toxml(
         _TABLE1, _TABLE1,
-        check=('//tr', ('th', 'td')),
+        check=('.//tr', ('th', 'td')),
         root='table',
         head='thead/tr/th',
         rows='tbody/tr/td'
@@ -591,7 +591,7 @@ def test_toxml20():
 def test_toxml21():
     _check_toxml(
         _TABLE1, _TAB_HAZ,
-        check=('//row', 'col'),
+        check=('.//row', 'col'),
         root='book',
         head='thead/row/col',
         rows='tbody/row/col',

--- a/petl/util/lookups.py
+++ b/petl/util/lookups.py
@@ -73,10 +73,10 @@ def lookup(table, key, value=None, dictionary=None):
         ... # object, including persistent dictionaries created via the
         ... # shelve module
         ... import shelve
-        >>> lkp = shelve.open('example.dat', flag='n')
+        >>> lkp = shelve.open('example1.dat', flag='n')
         >>> lkp = etl.lookup(table1, 'foo', 'bar', lkp)
         >>> lkp.close()
-        >>> lkp = shelve.open('example.dat', flag='r')
+        >>> lkp = shelve.open('example1.dat', flag='r')
         >>> lkp['a']
         [1]
         >>> lkp['b']
@@ -150,10 +150,10 @@ def lookupone(table, key, value=None, dictionary=None, strict=False):
         ... # object, including persistent dictionaries created via the
         ... # shelve module
         ... import shelve
-        >>> lkp = shelve.open('example.dat', flag='n')
+        >>> lkp = shelve.open('example2.dat', flag='n')
         >>> lkp = etl.lookupone(table1, 'foo', 'bar', lkp)
         >>> lkp.close()
-        >>> lkp = shelve.open('example.dat', flag='r')
+        >>> lkp = shelve.open('example2.dat', flag='r')
         >>> lkp['a']
         1
         >>> lkp['b']
@@ -213,13 +213,13 @@ def dictlookup(table, key, dictionary=None):
         ... # object, including persistent dictionaries created via the
         ... # shelve module
         ... import shelve
-        >>> lkp = shelve.open('example.dat', flag='n')
-        >>> lkp = etl.dictlookup(table1, 'foo', lkp)
-        >>> lkp.close()
-        >>> lkp = shelve.open('example.dat', flag='r')
-        >>> lkp['a']
+        >>> lok = shelve.open('example3.dat', flag='n')
+        >>> lok = etl.dictlookup(table1, 'foo', lok)
+        >>> lok.close()
+        >>> lup = shelve.open('example3.dat', flag='r')
+        >>> lup['a']
         [{'foo': 'a', 'bar': 1}]
-        >>> lkp['b']
+        >>> lup['b']
         [{'foo': 'b', 'bar': 2}, {'foo': 'b', 'bar': 3}]
 
     """
@@ -294,10 +294,10 @@ def dictlookupone(table, key, dictionary=None, strict=False):
         ... # object, including persistent dictionaries created via the
         ... # shelve module
         ... import shelve
-        >>> lkp = shelve.open('example.dat', flag='n')
+        >>> lkp = shelve.open('example4.dat', flag='n')
         >>> lkp = etl.dictlookupone(table1, 'foo', lkp)
         >>> lkp.close()
-        >>> lkp = shelve.open('example.dat', flag='r')
+        >>> lkp = shelve.open('example4.dat', flag='r')
         >>> lkp['a']
         {'foo': 'a', 'bar': 1}
         >>> lkp['b']

--- a/requirements-formats.txt
+++ b/requirements-formats.txt
@@ -8,9 +8,9 @@ pandas
 Whoosh>=2.7.4
 xlrd>=2.0.1
 xlwt>=1.3.0
-fastavro>=0.24.2 ; python_version >= '3.4'
-fastavro==0.24.2 ; python_version < '3.0'
-gspread>=3.4.0 ; python_version >= '3.4'
+fastavro>=0.24.2 ; python_version >= '3'
+fastavro==0.24.2 ; python_version < '3'
+gspread>=3.4.0 ; python_version >= '3'
 
 # version 3.9.2 fails with python3.12 on macos-latest: PyTables/PyTables#1093
 tables ; sys_platform != 'darwin'

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -12,7 +12,7 @@
 # 3.2 $ export C_INCLUDE_PATH=/usr/include/python3.11/Python.h
 
 
-blosc  ; python_version >= '3.7'
+blosc  ; python_version >= '3.7' and python_version != '3.13'
 
 # Throubleshooting: 
 # 1. $ pip install --prefer-binary -r requirements-optional.txt

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -18,4 +18,4 @@ blosc  ; python_version >= '3.7'
 # 1. $ pip install --prefer-binary -r requirements-optional.txt
 # 2. $ pip install --prefer-binary bcolz
 
-bcolz  ; python_version >= '3.7' and python_version < '3.10'
+bcolz  ; python_version >= '3.7' and python_version < '3.9.9'

--- a/requirements-remote.txt
+++ b/requirements-remote.txt
@@ -1,9 +1,9 @@
 # packages for testing remote sources
 
-fastavro>=0.24.2 ; python_version >= '3.4'
+fastavro>=0.24.2 ; python_version >= '3'
 smbprotocol>=1.0.1
 paramiko>=2.7.1
-requests; python_version >= '3.4'
-fsspec>=0.7.4 ; python_version >= '3.4'
-aiohttp>=3.6.2 ; python_version >= '3.5.3'
-s3fs>=0.2.2 ; python_version >= '3.4'
+requests; python_version >= '3'
+fsspec>=0.7.4 ; python_version >= '3'
+aiohttp>=3.6.2 ; python_version >= '3.5.3' or ( python_version > '3.10' and python_version < '3.2' )
+s3fs>=0.2.2 ; python_version >= '3'

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,7 +3,7 @@ setuptools
 pytest-cov>=2.12.0
 pytest>=4.6.6,<7.0.0
 tox
-coveralls
 coverage
 setuptools-scm
 mock; python_version < '3.0'
+coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,14 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37, py38, py39, py310, py311, {py36,py37,py38,py39,py310,py311,py312}-docs
+envlist = py27, py36, py37, py38, py39, py310, py311, py312, py313, {py36,py37,py38,py39,py310,py311,py312,py313}-docs
 
 [testenv]
 # get stable output for unordered types
 setenv =
     PYTHONHASHSEED = 42
     py27: PY_MAJOR_VERSION = py2
-    py36,py37,py38,py39,py310,py311,py312: PY_MAJOR_VERSION = py3
+    py36,py37,py38,py39,py310,py311,py312,py313: PY_MAJOR_VERSION = py3
 commands =
     pytest --cov=petl --cov-report lcov:lcov.info petl
     coverage report -m
@@ -19,7 +19,7 @@ deps =
     -rrequirements-tests.txt
     -rrequirements-formats.txt
 
-[testenv:{py36,py37,py38,py39,py310,py311,py312}-docs]
+[testenv:{py36,py37,py38,py39,py310,py311,py312,py313}-docs]
 # build documentation under similar environment to readthedocs
 changedir = docs
 deps =
@@ -27,9 +27,9 @@ deps =
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
-[testenv:{py36,py37,py38,py39,py310,py311,py312}-doctest]
+[testenv:{py36,py37,py38,py39,py310,py311,py312,py313}-doctest]
 commands =
-    py36,py37,py38,py39,py310,py311,py312: pytest --doctest-modules --cov=petl --cov-report lcov:lcov.info petl
+    py36,py37,py38,py39,py310,py311,py312,py313: pytest --doctest-modules --cov=petl --cov-report lcov:lcov.info petl
 [testenv:{py36,py37,py38,py39}-dochtml]
 changedir = docs
 deps =


### PR DESCRIPTION
## Upgrade Python versions supported by setup-python and runner-images on Github Actions

This PR aims to fix CI automated tests broken by the [end of support policy](https://github.com/actions/runner-images#support-policy) for the Python versions [2.7 up to 3.7](https://github.com/actions/runner-images/issues/6399).

The fix will require an upgrade to the [supported python versions](https://github.com/marketplace/actions/setup-python) in the latest version of [GitHub Actions Runner Images](https://github.com/actions/runner-images#available-images).

## Changes

1. Added links to Github actions [setup-python](https://github.com/marketplace/actions/setup-python) and [runner-images](https://github.com/actions/runner-images#available-images)
2. Avoid failures due to unsupported Python versions in the CI [test-changes](https://github.com/petl-developers/petl/actions/workflows/test-changes.yml) jobs regarding OS/Python versions:
    1. [ubuntu-latest/ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#python): Failing: `2.7, 3.6, 3.7` Working: `3.8 to 3.12`
    2. [macos-latest/macos-14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#python): Failing: `3.6, 3.7` Working: `3.8 to 3.12`
    3. [windows-latest/windows-2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#python): Working: `3.6 to 3.12`
3. Add Python version [3.13](https://docs.python.org/3/whatsnew/3.13.html) to test matrix.
4. Investigate [pytables](https://www.pytables.org/) test error due to [ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject](https://github.com/petl-developers/petl/blob/1e77626f17f6a89697abd17fd9d98b2ad9ed41cb/petl/test/io/test_pytables.py#L18) when running in `ubuntu-latest` with python `3.9 to 3.12`
5. Investigate [numpy](https://numpy.org/) documentation [test error](https://github.com/petl-developers/petl/blob/1e77626f17f6a89697abd17fd9d98b2ad9ed41cb/petl/io/numpy.py#L127) when running in `ubuntu-latest` with python `3.10` due to any of:
    1. [DeprecationWarning: Data type alias 'a' was deprecated in NumPy 2.0. Use the 'S' alias instead.](https://github.com/petl-developers/petl/blob/1e77626f17f6a89697abd17fd9d98b2ad9ed41cb/petl/io/numpy.py#L94) 
    2. [FutureWarning: This search incorrectly ignores the root element, and will be fixed in a future version.  If you rely on the current behaviour, change it to './/tr'](https://github.com/petl-developers/petl/blob/1e77626f17f6a89697abd17fd9d98b2ad9ed41cb/petl/io/numpy.py#L187)

## Checklist

Use this checklist to ensure the quality of pull requests that include new code and/or make changes to existing code.

* [ ] Source Code guidelines:
  * [ ] Includes unit tests
  * [ ] New functions have docstrings with examples that can be run with doctest
  * [ ] New functions are included in API docs
  * [ ] Docstrings include notes for any changes to API or behavior
  * [ ] All changes are documented in docs/changes.rst
* [x] Versioning and history tracking guidelines:
  * [x] Using atomic commits whenever possible
  * [x] Commits are reversible whenever possible
  * [x] There are no incomplete changes in the pull request
  * [x] There is no accidental garbage added to the source code
* [x] Testing guidelines:
  * [x] Tested locally using `tox` / `pytest`
  * [x] Rebased to `master` branch and tested before sending the PR
  * [x] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [x] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [ ] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [x] Ready to review
  * [x] Ready to merge
