### PR TITLE
build and publish a wheel

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,10 +34,9 @@ jobs:
         run: |
           python -m pip install build --user
 
-      - name: Build the petl package as source tarball
+      - name: Build the petl package
         run: |
-          # python setup.py sdist
-          python -m build --sdist --outdir dist/ .
+          python -m build --outdir dist/ .
 
       - name: Publish the package version ${{ github.event.release.tag_name }} to PyPI
         if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
this project currently publishes only a source distribution, so every user has to build a wheel for themselves.  This is slower and can go wrong.

Better for package maintainers to build and publish a wheel once and for all