### PR TITLE
Added ability to infer JSON column type into db_create.py and added t…

### DIFF
--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --prefer-binary -r requirements-tests.txt
+          python -m pip install SQLAlchemy
 
       - name: Setup environment variables for remote filesystem testing with primary = ${{ matrix.primary }}
         if: matrix.os == 'ubuntu-latest' && matrix.python == matrix.primary

--- a/petl/io/db_create.py
+++ b/petl/io/db_create.py
@@ -100,6 +100,9 @@ def make_sqlalchemy_column(col, colname, constraints=True):
     elif all(isinstance(v, datetime.time) for v in col_not_none):
         sql_column_type = sqlalchemy.Time
 
+    elif all(isinstance(v, (dict, list)) for v in col_not_none):
+        sql_column_type = sqlalchemy.JSON
+
     else:
         sql_column_type = sqlalchemy.String
         if constraints:

--- a/petl/test/io/test_int_column.py
+++ b/petl/test/io/test_int_column.py
@@ -1,0 +1,7 @@
+from petl.io.db_create import make_sqlalchemy_column
+from sqlalchemy import Integer
+
+def test_int_inference():
+    col = make_sqlalchemy_column([1, 2, 3], 'n')
+    assert col.name == 'n'
+    assert isinstance(col.type, Integer)

--- a/petl/test/io/test_json_column.py
+++ b/petl/test/io/test_json_column.py
@@ -1,0 +1,8 @@
+from petl.io.db_create import make_sqlalchemy_column
+from sqlalchemy import JSON
+
+def test_json_inference():
+    data = [{'a': 1}, {'b': 2}, None]
+    col = make_sqlalchemy_column(data, 'payload')
+    assert col.name == 'payload'
+    assert isinstance(col.type, JSON)


### PR DESCRIPTION
This pull request adds inference of JSON columns from Python dict/list data, mapping them to sqlalchemy..JSON in db_create.py. 

It also includes two new tests:

- test_int_column.py for integer 
- test_json_column.py for JSON 

All existing tests pass.

Closes #644
