### PR TITLE
ci: fix codacy action failing due to mistyped yaml file

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -73,11 +73,11 @@ jobs:
           max-allowed-issues: 2147483647
 
       - name: Fetch SARIF files
-          uses: actions/download-artifact@v4
-          with:
-            path: ../results
-            pattern: *.sarif
-            merge-multiple: true
+        uses: actions/download-artifact@v4
+        with:
+          path: ../results
+          pattern: *.sarif
+          merge-multiple: true
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file


### PR DESCRIPTION
This PR has the objective of fixing the codacy yaml file.

## Changes

1. Fixed indentation in the codacity yaml file
