### PR TITLE
Add drop="if_exists" support to todb()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,9 @@ Version 1.7.17
 * fix: mitigate code injection related in #672
   By :user:`juarezr`, :issue:`681`.
 
+* Add ``drop='if_exists'`` support to :func:`petl.io.db.todb`.
+  :issue:`666`.
+
 Version 1.7.16
 --------------
 

--- a/petl/io/db.py
+++ b/petl/io/db.py
@@ -288,9 +288,10 @@ def todb(table, dbo, tablename, schema=None, commit=True,
     create : bool
         If True attempt to create the table before loading, inferring types
         from a sample of the data (requires SQLAlchemy)
-    drop : bool
+    drop : bool or 'if_exists'
         If True attempt to drop the table before recreating (only relevant if
-        create=True)
+        create=True). If 'if_exists', do not raise an error if the table does
+        not exist.
     constraints : bool
         If True use length and nullable constraints (only relevant if
         create=True)
@@ -349,7 +350,9 @@ def todb(table, dbo, tablename, schema=None, commit=True,
     try:
         if create:
             if drop:
-                drop_table(dbo, tablename, schema=schema, commit=commit)
+                if_exists = drop == 'if_exists'
+                drop_table(dbo, tablename, schema=schema, commit=commit,
+                           if_exists=if_exists)
             create_table(table, dbo, tablename, schema=schema, commit=commit,
                          constraints=constraints, metadata=metadata,
                          dialect=dialect, sample=sample)

--- a/petl/io/db_create.py
+++ b/petl/io/db_create.py
@@ -229,7 +229,7 @@ def create_table(table, dbo, tablename, schema=None, commit=True,
     _execute(sql, dbo, commit=commit)
 
 
-def drop_table(dbo, tablename, schema=None, commit=True):
+def drop_table(dbo, tablename, schema=None, commit=True, if_exists=False):
     """
     Drop a database table.
 
@@ -244,6 +244,8 @@ def drop_table(dbo, tablename, schema=None, commit=True):
         Name of the database schema the table is in
     commit : bool
         If True commit the changes
+    if_exists : bool
+        If True, do not raise an error if the table does not exist
 
     """
 
@@ -252,7 +254,10 @@ def drop_table(dbo, tablename, schema=None, commit=True):
     if schema is not None:
         tablename = _quote(schema) + '.' + tablename
 
-    sql = u'DROP TABLE %s' % tablename
+    if if_exists:
+        sql = u'DROP TABLE IF EXISTS %s' % tablename
+    else:
+        sql = u'DROP TABLE %s' % tablename
     _execute(sql, dbo, commit)
 
 

--- a/petl/test/io/test_db.py
+++ b/petl/test/io/test_db.py
@@ -7,14 +7,96 @@ from tempfile import NamedTemporaryFile
 from petl.compat import next
 
 
+import petl.io.db as db
 from petl.test.helpers import ieq, eq_
 from petl.io.db import fromdb, todb, appenddb
+from petl.io.db_create import drop_table
 
 
 # N.B., this file only tests the DB-related functions using sqlite3,
 # as anything else requires database connection configuration. See
 # docs/dbtests.py for a script to exercise the DB-related functions with
 # MySQL and Postgres.
+
+
+class LoggingConnection(object):
+
+    def __init__(self):
+        self.sql = []
+
+    def cursor(self):
+        return self
+
+    def execute(self, sql):
+        self.sql.append(sql)
+
+    def close(self):
+        pass
+
+    def commit(self):
+        pass
+
+
+def test_drop_table_if_exists_sql():
+    dbo = LoggingConnection()
+
+    drop_table(dbo, 'test_create', commit=False)
+    drop_table(dbo, 'test_create', commit=False, if_exists=True)
+
+    eq_([u'DROP TABLE "test_create"',
+         u'DROP TABLE IF EXISTS "test_create"'],
+        dbo.sql)
+
+
+def _record_todb_create_calls(monkeypatch, drop):
+    calls = []
+
+    def fake_drop_table(dbo, tablename, schema=None, commit=True,
+                        if_exists=False):
+        calls.append(('drop', tablename, if_exists))
+
+    def fake_create_table(table, dbo, tablename, schema=None, commit=True,
+                          constraints=True, metadata=None, dialect=None,
+                          sample=1000):
+        calls.append(('create', tablename))
+
+    def fake_todb(table, dbo, tablename, schema=None, commit=True,
+                  truncate=False):
+        calls.append(('load', tablename, truncate))
+
+    monkeypatch.setattr(db, 'drop_table', fake_drop_table)
+    monkeypatch.setattr(db, 'create_table', fake_create_table)
+    monkeypatch.setattr(db, '_todb', fake_todb)
+
+    table = (('foo',), ('a',))
+    todb(table, object(), 'foobar', create=True, drop=drop)
+    return calls
+
+
+def test_todb_drop_false_skips_drop(monkeypatch):
+    calls = _record_todb_create_calls(monkeypatch, False)
+
+    eq_([('create', 'foobar'),
+         ('load', 'foobar', True)],
+        calls)
+
+
+def test_todb_drop_true_uses_plain_drop(monkeypatch):
+    calls = _record_todb_create_calls(monkeypatch, True)
+
+    eq_([('drop', 'foobar', False),
+         ('create', 'foobar'),
+         ('load', 'foobar', True)],
+        calls)
+
+
+def test_todb_drop_if_exists_uses_if_exists(monkeypatch):
+    calls = _record_todb_create_calls(monkeypatch, 'if_exists')
+
+    eq_([('drop', 'foobar', True),
+         ('create', 'foobar'),
+         ('load', 'foobar', True)],
+        calls)
 
 
 def test_fromdb():

--- a/petl/test/io/test_db_create.py
+++ b/petl/test/io/test_db_create.py
@@ -46,6 +46,19 @@ def _test_create(dbo):
     else:
         raise Exception('expected exception not raised')
 
+    debug('verify create with drop if exists when missing')
+    todb(expect, dbo, 'test_create_if_exists', create=True,
+         drop='if_exists')
+    actual_if_exists = fromdb(dbo, 'SELECT * FROM test_create_if_exists')
+    ieq(expect, actual_if_exists)
+    debug(look(actual_if_exists))
+
+    debug('verify recreate with drop if exists')
+    todb(expect_extended, dbo, 'test_create_if_exists', create=True,
+         drop='if_exists')
+    ieq(expect_extended, actual_if_exists)
+    debug(look(actual_if_exists))
+
     debug('create table and verify')
     todb(expect, dbo, 'test_create', create=True)
     ieq(expect, actual)
@@ -80,6 +93,7 @@ def _setup_mysql(dbapi_connection):
     # deal with quote compatibility
     cursor.execute('SET SQL_MODE=ANSI_QUOTES')
     cursor.execute('DROP TABLE IF EXISTS test_create')
+    cursor.execute('DROP TABLE IF EXISTS test_create_if_exists')
     cursor.execute('DROP TABLE IF EXISTS "foo "" bar`"')
     cursor.close()
     dbapi_connection.commit()
@@ -89,6 +103,7 @@ def _setup_generic(dbapi_connection):
     # setup table
     cursor = dbapi_connection.cursor()
     cursor.execute('DROP TABLE IF EXISTS test_create')
+    cursor.execute('DROP TABLE IF EXISTS test_create_if_exists')
     cursor.execute('DROP TABLE IF EXISTS "foo "" bar`"')
     cursor.close()
     dbapi_connection.commit()


### PR DESCRIPTION
Closes #666.

This PR has the objective of adding an idempotent drop mode to `todb()` so ETL jobs can recreate target tables whether or not the table already exists.

## Changes

1. Added support for `drop="if_exists"` when using `todb(..., create=True)`.
2. Fixed the missing-table recreate case by allowing `todb()` to call `drop_table(..., if_exists=True)` before creating the table.
3. Preserved the existing `drop=True` behavior, which still issues a normal `DROP TABLE` and raises if the table does not exist.
4. Updated the database table drop helper to emit `DROP TABLE IF EXISTS` only for the new `if_exists` mode.
5. Added regression tests for the new `drop="if_exists"` behavior.
6. Documented the change in `docs/changes.rst`.

## Testing

- `.venv/bin/python -m pytest petl/test/io/test_db.py petl/test/io/test_db_create.py`

Result:

- `12 passed, 2 skipped, 2 warnings`

The warnings are existing sqlite generator cleanup warnings from `test_fromdb`.

## Checklist

Use this checklist to ensure the quality of pull requests that include new code and/or make changes to existing code.

* [x] Source Code guidelines:
  * [x] Includes unit tests
  * [x] New functions have docstrings with examples that can be run with doctest
  * [x] New functions are included in API docs
  * [x] Docstrings include notes for any changes to API or behavior
  * [x] All changes are documented in docs/changes.rst
* [x] Versioning and history tracking guidelines:
  * [x] Using atomic commits whenever possible
  * [x] Commits are reversible whenever possible
  * [x] There are no incomplete changes in the pull request
  * [x] There is no accidental garbage added to the source code
* [x] Testing guidelines:
  * [x] Tested locally using `tox` / `pytest`
  * [x] Rebased to `master` branch and tested before sending the PR
  * [ ] Automated testing passes (see [CI](https://github.com/petl-developers/petl/actions))
  * [ ] Unit test coverage has not decreased (see [Coveralls](https://coveralls.io/github/petl-developers/petl))
* [x] State of these changes is:
  * [ ] Just a proof of concept
  * [ ] Work in progress / Further changes needed
  * [x] Ready to review
  * [ ] Ready to merge