### PR TITLE
Fix DictsView.dicts instance attr shadowing Table.dicts() method

### DIFF
--- a/petl/io/json.py
+++ b/petl/io/json.py
@@ -191,6 +191,51 @@ def fromdicts(dicts, header=None, sample=1000, missing=None):
     return view(dicts, header=header, sample=sample, missing=missing)
 
 
+class _DictsAttr(object):
+    """Reads as the input data, calls as the inherited Table.dicts() method.
+
+    Only exists to keep `.dicts` working both ways in the v1.x series; v2 can
+    drop it along with the property below.
+    """
+
+    def __init__(self, view):
+        self._view = view
+
+    def __call__(self, *sliceargs, **kwargs):
+        return _dicts(self._view, *sliceargs, **kwargs)
+
+    def __iter__(self):
+        return iter(self._view._dicts)
+
+    def __next__(self):
+        return next(self._view._dicts)
+
+    next = __next__
+
+    def __len__(self):
+        return len(self._view._dicts)
+
+    def __getitem__(self, item):
+        return self._view._dicts[item]
+
+    def __eq__(self, other):
+        return self._view._dicts == other
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._view._dicts)
+
+    def __repr__(self):
+        return repr(self._view._dicts)
+
+    def __getattr__(self, name):
+        if name.startswith('_'):
+            raise AttributeError(name)
+        return getattr(self._view._dicts, name)
+
+
 class DictsView(Table):
 
     def __init__(self, dicts, header=None, sample=1000, missing=None):
@@ -201,6 +246,17 @@ class DictsView(Table):
 
     def __iter__(self):
         return iterdicts(self._dicts, self._header, self.sample, self.missing)
+
+    @property
+    def dicts(self):
+        # `.dicts` was the raw input data, which shadowed Table.dicts() (#643).
+        # A property on the subclass wins over the inherited method, so both
+        # uses keep working until v2.
+        return _DictsAttr(self)
+
+    @dicts.setter
+    def dicts(self, value):
+        self._dicts = value
 
 
 class DictsGeneratorView(DictsView):

--- a/petl/io/json.py
+++ b/petl/io/json.py
@@ -194,13 +194,13 @@ def fromdicts(dicts, header=None, sample=1000, missing=None):
 class DictsView(Table):
 
     def __init__(self, dicts, header=None, sample=1000, missing=None):
-        self.dicts = dicts
+        self._dicts = dicts
         self._header = header
         self.sample = sample
         self.missing = missing
 
     def __iter__(self):
-        return iterdicts(self.dicts, self._header, self.sample, self.missing)
+        return iterdicts(self._dicts, self._header, self.sample, self.missing)
 
 
 class DictsGeneratorView(DictsView):
@@ -222,7 +222,7 @@ class DictsGeneratorView(DictsView):
                 self._filecache = NamedTemporaryFile(delete=False, mode='wb+', buffering=0)
 
         position = 0
-        it = iter(self.dicts)
+        it = iter(self._dicts)
         while True:
             if position < self._cached:
                 self._filecache.seek(position)
@@ -241,10 +241,10 @@ class DictsGeneratorView(DictsView):
             yield row
 
     def _determine_header(self):
-        it = iter(self.dicts)
+        it = iter(self._dicts)
         header = list()
         peek, it = iterpeek(it, self.sample)
-        self.dicts = it
+        self._dicts = it
         if isinstance(peek, dict):
             peek = [peek]
         for o in peek:

--- a/petl/test/io/test_json.py
+++ b/petl/test/io/test_json.py
@@ -342,11 +342,42 @@ def test_fromdicts_generator_missing():
 
 
 def test_fromdicts_dicts_method():
-    # fromdicts() returns a DictsView whose internal data attribute was named
-    # 'dicts', shadowing the inherited Table.dicts() method.  Calling .dicts()
-    # on the result should return row dicts, not raise TypeError.
+    # .dicts() must reach the inherited Table.dicts(), not the input data (#643)
     dummy = dummytable(numrows=3, seed=42)
     data = list(dummy.dicts())
     actual = fromdicts(dummy.dicts())
-    result = list(actual.dicts())
-    assert result == data
+    assert list(actual.dicts()) == data
+
+
+def test_fromdicts_dicts_attribute_reads_as_data():
+    data = [{'foo': 'a', 'bar': 1}, {'foo': 'b', 'bar': 2}]
+    actual = fromdicts(data)
+    assert actual.dicts == data
+    assert list(actual.dicts) == data
+    assert len(actual.dicts) == 2
+    assert actual.dicts[1] == data[1]
+    assert repr(actual.dicts) == repr(data)
+
+
+def test_fromdicts_dicts_attribute_assignment():
+    actual = fromdicts([{'foo': 'a'}])
+    actual.dicts = [{'foo': 'z'}]
+    assert list(actual.dicts) == [{'foo': 'z'}]
+    ieq((('foo',), ('z',)), actual)
+
+
+def test_fromdicts_generator_dicts_method(dicts_generator):
+    actual = fromdicts(dicts_generator)
+    expect = [{'foo': 'a', 'bar': 1},
+              {'foo': 'b', 'bar': 2},
+              {'foo': 'c', 'bar': 2}]
+    assert list(actual.dicts()) == expect
+
+
+def test_fromdicts_generator_dicts_attribute_is_consumable(dicts_generator):
+    # the generator view's .dicts is a one-shot iterator, as it was before
+    actual = fromdicts(dicts_generator)
+    it = actual.dicts
+    assert next(it) == {'foo': 'a', 'bar': 1}
+    assert len(list(it)) == 2
+    assert list(actual.dicts) == []

--- a/petl/test/io/test_json.py
+++ b/petl/test/io/test_json.py
@@ -339,3 +339,19 @@ def test_fromdicts_generator_missing():
               ('b', 2, "x"),
               ('c', "x", 2))
     ieq(expect, actual)
+
+
+def test_fromdicts_dicts_method():
+    # fromdicts() returns a DictsView whose internal data attribute was named
+    # 'dicts', shadowing the inherited Table.dicts() method.  Calling .dicts()
+    # on the result should return row dicts, not raise TypeError.
+    data = [{'foo': 'a', 'bar': 1},
+            {'foo': 'b', 'bar': 2},
+            {'foo': 'c', 'bar': 2}]
+    actual = fromdicts(data, header=['foo', 'bar'])
+    result = list(actual.dicts())
+    assert result == [
+        {'foo': 'a', 'bar': 1},
+        {'foo': 'b', 'bar': 2},
+        {'foo': 'c', 'bar': 2},
+    ]

--- a/petl/test/io/test_json.py
+++ b/petl/test/io/test_json.py
@@ -8,7 +8,7 @@ import json
 import pytest
 
 from petl.test.helpers import ieq
-from petl import fromjson, fromdicts, tojson, tojsonarrays
+from petl import dummytable, fromjson, fromdicts, tojson, tojsonarrays
 
 
 def test_fromjson_1():
@@ -345,13 +345,8 @@ def test_fromdicts_dicts_method():
     # fromdicts() returns a DictsView whose internal data attribute was named
     # 'dicts', shadowing the inherited Table.dicts() method.  Calling .dicts()
     # on the result should return row dicts, not raise TypeError.
-    data = [{'foo': 'a', 'bar': 1},
-            {'foo': 'b', 'bar': 2},
-            {'foo': 'c', 'bar': 2}]
-    actual = fromdicts(data, header=['foo', 'bar'])
+    dummy = dummytable(numrows=3, seed=42)
+    data = list(dummy.dicts())
+    actual = fromdicts(dummy.dicts())
     result = list(actual.dicts())
-    assert result == [
-        {'foo': 'a', 'bar': 1},
-        {'foo': 'b', 'bar': 2},
-        {'foo': 'c', 'bar': 2},
-    ]
+    assert result == data


### PR DESCRIPTION
`fromdicts()` returns a `DictsView` that stores its input as `self.dicts`, which shadows the `dicts()` method `Table` picks up from `Table.dicts = dicts` in `petl/util/base.py`. The instance attribute wins attribute lookup, so:

```python
>>> import petl as etl
>>> etl.fromdicts(etl.dummytable().dicts()).dicts()
TypeError: 'DictsView' object is not callable
```

Renames the internal attribute to `self._dicts` in `DictsView` and `DictsGeneratorView`, following the `self._header` convention 5498411 introduced on this same class for the same collision (released in 1.7.5 as "Fix `fromdicts(...).header()` raising TypeError").

The last commit is separable: it keeps `.dicts` readable as the input data via a property on `DictsView`, so the attribute behaves as it does today while `.dicts()` starts working. Drop that commit for the plain rename.

Fixes #643.

---

This pull request was prepared with the assistance of AI, under my direction and review.
