### PR TITLE
Fix header instance attribute shadowing Table.header() across views

### DIFF
--- a/petl/io/base.py
+++ b/petl/io/base.py
@@ -62,11 +62,11 @@ class ColumnsView(Table):
 
     def __init__(self, cols, header=None, missing=None):
         self.cols = cols
-        self.header = header
+        self._header = header
         self.missing = missing
 
     def __iter__(self):
-        return itercolumns(self.cols, self.header, self.missing)
+        return itercolumns(self.cols, self._header, self.missing)
 
 
 def itercolumns(cols, header, missing):

--- a/petl/io/csv_py2.py
+++ b/petl/io/csv_py2.py
@@ -23,11 +23,11 @@ class CSVView(Table):
         self.encoding = encoding
         self.errors = errors
         self.csvargs = csvargs
-        self.header = header
+        self._header = header
 
     def __iter__(self):
-        if self.header is not None:
-            yield tuple(self.header)
+        if self._header is not None:
+            yield tuple(self._header)
 
         # determine encoding
         codec = getcodec(self.encoding)

--- a/petl/io/csv_py3.py
+++ b/petl/io/csv_py3.py
@@ -24,11 +24,11 @@ class CSVView(Table):
         self.encoding = encoding
         self.errors = errors
         self.csvargs = csvargs
-        self.header = header
+        self._header = header
 
     def __iter__(self):
-        if self.header is not None:
-            yield tuple(self.header)
+        if self._header is not None:
+            yield tuple(self._header)
         with self.source.open('rb') as buf:
             csvfile = io.TextIOWrapper(buf, encoding=self.encoding,
                                        errors=self.errors, newline='')

--- a/petl/io/json.py
+++ b/petl/io/json.py
@@ -96,7 +96,7 @@ class JsonView(Table):
     def __init__(self, source, *args, **kwargs):
         self.source = source
         self.missing = kwargs.pop('missing', None)
-        self.header = kwargs.pop('header', None)
+        self._header = kwargs.pop('header', None)
         self.sample = kwargs.pop('sample', 1000)
         self.lines = kwargs.pop('lines', False)
         self.args = args
@@ -110,11 +110,11 @@ class JsonView(Table):
                                      write_through=True)
             try:
                 if self.lines:
-                    for row in iterjlines(f, self.header, self.missing):
+                    for row in iterjlines(f, self._header, self.missing):
                         yield row
                 else:
                     dicts = json.load(f, *self.args, **self.kwargs)
-                    for row in iterdicts(dicts, self.header, self.sample,
+                    for row in iterdicts(dicts, self._header, self.sample,
                                          self.missing):
                         yield row
             finally:

--- a/petl/io/text.py
+++ b/petl/io/text.py
@@ -68,7 +68,7 @@ class TextView(Table):
     def __init__(self, source, header=('lines',), encoding=None,
                  errors='strict', strip=None):
         self.source = source
-        self.header = header
+        self._header = header
         self.encoding = encoding
         self.errors = errors
         self.strip = strip
@@ -88,8 +88,8 @@ class TextView(Table):
 
             # generate the table
             try:
-                if self.header is not None:
-                    yield tuple(self.header)
+                if self._header is not None:
+                    yield tuple(self._header)
                 if self.strip is False:
                     for line in f:
                         yield (line,)

--- a/petl/test/test_method_shadow.py
+++ b/petl/test/test_method_shadow.py
@@ -1,0 +1,123 @@
+"""
+Regression tests for Table subclasses whose stored ``header`` argument
+shadowed the inherited ``Table.header()`` method, so calling the fluent
+``.header()`` raised ``TypeError: '...' object is not callable``.
+
+See issue #555 (fixed the same collision on ``fromdicts``) and PR #697.
+"""
+
+from __future__ import absolute_import, print_function, division
+
+
+import json as _json
+from tempfile import NamedTemporaryFile
+
+
+import pytest
+
+
+import petl as etl
+from petl.compat import PY2
+from petl.test.helpers import eq_
+
+
+def _csvfile(text):
+    f = NamedTemporaryFile(mode='w', suffix='.csv', delete=False, newline='')
+    f.write(text)
+    f.close()
+    return f.name
+
+
+def _textfile(text):
+    f = NamedTemporaryFile(mode='w', suffix='.txt', delete=False)
+    f.write(text)
+    f.close()
+    return f.name
+
+
+def _jsonfile(obj):
+    f = NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+    f.write(_json.dumps(obj))
+    f.close()
+    return f.name
+
+
+@pytest.mark.skipif(PY2, reason='NamedTemporaryFile newline kwarg is Python 3 only')
+def test_fromcsv_header():
+    t = etl.fromcsv(_csvfile('foo,bar\r\n1,2\r\n'))
+    eq_(('foo', 'bar'), t.header())
+
+
+def test_fromtext_header():
+    t = etl.fromtext(_textfile('line one\nline two\n'))
+    eq_(('lines',), t.header())
+
+
+def test_fromjson_header():
+    t = etl.fromjson(_jsonfile([{'foo': 1, 'bar': 2}]), header=['foo', 'bar'])
+    eq_(('foo', 'bar'), t.header())
+
+
+def test_fromcolumns_header():
+    t = etl.fromcolumns([[1, 2], [3, 4]], ['a', 'b'])
+    eq_(('a', 'b'), t.header())
+
+
+def test_cat_header():
+    a = etl.wrap([['foo', 'bar'], [1, 2]])
+    b = etl.wrap([['foo', 'baz'], [3, 4]])
+    t = etl.cat(a, b, header=['foo', 'bar', 'baz'])
+    eq_(('foo', 'bar', 'baz'), t.header())
+
+
+def test_pushheader_header():
+    t = etl.pushheader(etl.wrap([[1, 2]]), ['foo', 'bar'])
+    eq_(('foo', 'bar'), t.header())
+
+
+def test_setheader_header():
+    t = etl.setheader(etl.wrap([['foo', 'bar'], [1, 2]]), ['a', 'b'])
+    eq_(('a', 'b'), t.header())
+
+
+def test_rowmap_header():
+    src = etl.wrap([['foo', 'bar'], [1, 2]])
+    t = etl.rowmap(src, lambda row: [row[0]], header=['foo'])
+    eq_(('foo',), t.header())
+
+
+def test_rowmapmany_header():
+    src = etl.wrap([['foo', 'bar'], [1, 2]])
+    t = etl.rowmapmany(src, lambda row: [[row[0]]], header=['foo'])
+    eq_(('foo',), t.header())
+
+
+def test_rowgroupmap_header():
+    src = etl.wrap([['foo', 'bar'], [1, 2]])
+    t = etl.rowgroupmap(src, 'foo', lambda k, rows: [[k]], header=['foo'])
+    eq_(('foo',), t.header())
+
+
+def test_rowreduce_header():
+    src = etl.wrap([['foo', 'bar'], [1, 2]])
+    t = etl.rowreduce(src, 'foo', lambda k, rows: [k], header=['foo'])
+    eq_(('foo',), t.header())
+
+
+def test_mergesort_header():
+    a = etl.wrap([['foo', 'bar'], [1, 2]])
+    b = etl.wrap([['foo', 'bar'], [3, 4]])
+    t = etl.mergesort(a, b, key='foo')
+    eq_(('foo', 'bar'), t.header())
+
+
+def test_validate_header():
+    src = etl.wrap([['foo', 'bar'], [1, 2]])
+    t = etl.validate(src, header=['foo', 'bar'])
+    eq_(('name', 'row', 'field', 'value', 'error'), t.header())
+
+
+def test_method_matches_function_form():
+    # the fluent method must agree with the etl.header() function
+    t = etl.fromcolumns([[1, 2]], ['a'])
+    eq_(etl.header(t), t.header())

--- a/petl/transform/basics.py
+++ b/petl/transform/basics.py
@@ -338,10 +338,10 @@ class CatView(Table):
     def __init__(self, sources, missing=None, header=None):
         self.sources = sources
         self.missing = missing
-        self.header = header
+        self._header = header
 
     def __iter__(self):
-        return itercat(self.sources, self.missing, self.header)
+        return itercat(self.sources, self.missing, self._header)
 
 
 def itercat(sources, missing, header):

--- a/petl/transform/headers.py
+++ b/petl/transform/headers.py
@@ -133,10 +133,10 @@ class SetHeaderView(Table):
 
     def __init__(self, source, header):
         self.source = source
-        self.header = header
+        self._header = header
 
     def __iter__(self):
-        return itersetheader(self.source, self.header)
+        return itersetheader(self.source, self._header)
 
 
 def itersetheader(source, header):
@@ -236,17 +236,17 @@ class PushHeaderView(Table):
         self.args = args
         # if user passes header as a list, just use this and ignore args
         if isinstance(header, (list, tuple)):
-            self.header = header
+            self._header = header
         # otherwise,
         elif len(args) > 0:
-            self.header = []
-            self.header.append(header)  # first argument is named header
-            self.header.extend(args)  # add the other positional arguments
+            self._header = []
+            self._header.append(header)  # first argument is named header
+            self._header.extend(args)  # add the other positional arguments
         else:
             assert False, 'bad parameters'
 
     def __iter__(self):
-        return iterpushheader(self.source, self.header)
+        return iterpushheader(self.source, self._header)
 
 
 def iterpushheader(source, header):

--- a/petl/transform/maps.py
+++ b/petl/transform/maps.py
@@ -210,12 +210,12 @@ class RowMapView(Table):
     def __init__(self, source, rowmapper, header, failonerror=None):
         self.source = source
         self.rowmapper = rowmapper
-        self.header = header
+        self._header = header
         self.failonerror = (config.failonerror if failonerror is None
                                 else failonerror)
 
     def __iter__(self):
-        return iterrowmap(self.source, self.rowmapper, self.header,
+        return iterrowmap(self.source, self.rowmapper, self._header,
                           self.failonerror)
 
 
@@ -307,12 +307,12 @@ class RowMapManyView(Table):
     def __init__(self, source, rowgenerator, header, failonerror=None):
         self.source = source
         self.rowgenerator = rowgenerator
-        self.header = header
+        self._header = header
         self.failonerror = (config.failonerror if failonerror is None
                                 else failonerror)
 
     def __iter__(self):
-        return iterrowmapmany(self.source, self.rowgenerator, self.header,
+        return iterrowmapmany(self.source, self.rowgenerator, self._header,
                               self.failonerror)
 
 
@@ -364,11 +364,11 @@ class RowGroupMapView(Table):
             self.source = sort(source, key, buffersize=buffersize,
                                tempdir=tempdir, cache=cache)
         self.key = key
-        self.header = header
+        self._header = header
         self.mapper = mapper
 
     def __iter__(self):
-        return iterrowgroupmap(self.source, self.key, self.mapper, self.header)
+        return iterrowgroupmap(self.source, self.key, self.mapper, self._header)
 
 
 def iterrowgroupmap(source, key, mapper, header):

--- a/petl/transform/reductions.py
+++ b/petl/transform/reductions.py
@@ -74,11 +74,11 @@ class RowReduceView(Table):
             self.source = sort(source, key, buffersize=buffersize, 
                                tempdir=tempdir, cache=cache)
         self.key = key
-        self.header = header
+        self._header = header
         self.reducer = reducer
 
     def __iter__(self):
-        return iterrowreduce(self.source, self.key, self.reducer, self.header)
+        return iterrowreduce(self.source, self.key, self.reducer, self._header)
 
     
 def iterrowreduce(source, key, reducer, header):

--- a/petl/transform/sorts.py
+++ b/petl/transform/sorts.py
@@ -472,11 +472,11 @@ class MergeSortView(Table):
                                 cache=cache)
                            for t in tables]
         self.missing = missing
-        self.header = header
+        self._header = header
         self.reverse = reverse
 
     def __iter__(self):
-        return itermergesort(self.tables, self.key, self.header, self.missing,
+        return itermergesort(self.tables, self.key, self._header, self.missing,
                              self.reverse)
 
 

--- a/petl/transform/validation.py
+++ b/petl/transform/validation.py
@@ -79,10 +79,10 @@ class ProblemsView(Table):
     def __init__(self, table, constraints, header):
         self.table = table
         self.constraints = constraints
-        self.header = header
+        self._header = header
 
     def __iter__(self):
-        return iterproblems(self.table, self.constraints, self.header)
+        return iterproblems(self.table, self.constraints, self._header)
 
 
 def normalize_constraints(constraints, flds):


### PR DESCRIPTION
`Table` binds `header()` as a class-level method, but several `Table`
subclasses store their `header` constructor argument as `self.header`.
The instance attribute shadows the method, so the fluent `.header()` call
raises `TypeError` on current master:

```python
>>> import petl as etl
>>> etl.fromcsv('data.csv').header()
TypeError: 'NoneType' object is not callable
>>> etl.fromtext('data.txt').header()
TypeError: 'tuple' object is not callable
```

The function form `etl.header(table)` works everywhere; only the method
is broken. This is the same collision `5498411` fixed for `fromdicts`
(renamed `self.header` -> `self._header`), released in **1.7.5** and
listed in `docs/changes.rst` as *"Fix `fromdicts(...).header()` raising
TypeError"* (issue #555). That fix only covered `DictsView` and even
missed its sibling `JsonView` in the same file.

This applies the identical rename to every remaining view that stores a
`header` argument, restoring `.header()`:

`fromcsv`, `fromtext`, `fromjson`, `fromcolumns`, `cat`, `pushheader`,
`setheader`, `rowmap`, `rowmapmany`, `rowgroupmap`, `rowreduce`,
`mergesort`, `validate`.

The renamed attribute is internal in every case (only read inside the
view's own `__iter__`, never exported, not documented), so this is the
same low-risk, method-restoring change #555 already shipped. Sibling
class of the merged #697 (`dicts`).

### Scope

Kept deliberately to the `header` collision, which #555 already
established as a bugfix. A wider audit found the same
attribute-shadows-method pattern for `cache` (join/sort views),
`complement` (select/search views), `skip` (avro/bcolz) and the
`addfield`/`movefield` `index` argument. Those are left for a separate
change since they lack the direct #555 precedent and one (`cache`) also
touches the `CacheView` storage rather than a plain constructor flag.

Tests: adds `petl/test/test_method_shadow.py` asserting `.header()`
returns the header on all 13 factories (each raised `TypeError` before).
Full suite green (`pytest petl` 566 passed / `--doctest-modules` 719
passed), no new failures or skips.

This pull request was prepared with the assistance of AI, under my direction and review.
