### PR TITLE
Fix cache/complement/index/skip attributes shadowing Table methods

### DIFF
--- a/petl/io/avro.py
+++ b/petl/io/avro.py
@@ -245,7 +245,7 @@ class AvroView(Table):
     def __init__(self, source, limit, skips, **avro_args):
         self.source = source
         self.limit = limit
-        self.skip = skips
+        self._skip = skips
         self.avro_args = avro_args
         self.avro_schema = None
 
@@ -281,7 +281,7 @@ class AvroView(Table):
         count = 0
         maximum = self.limit if self.limit is not None else sys.maxsize
         for i, record in enumerate(avro_reader):
-            if i < self.skip:
+            if i < self._skip:
                 continue
             if count >= maximum:
                 break

--- a/petl/io/bcolz.py
+++ b/petl/io/bcolz.py
@@ -64,7 +64,7 @@ class BcolzView(Table):
         self.expression = expression
         self.outcols = outcols
         self.limit = limit
-        self.skip = skip
+        self._skip = skip
 
     def __iter__(self):
 
@@ -86,10 +86,10 @@ class BcolzView(Table):
 
         # obtain iterator
         if self.expression is None:
-            it = ctbl.iter(outcols=self.outcols, skip=self.skip,
+            it = ctbl.iter(outcols=self.outcols, skip=self._skip,
                            limit=self.limit)
         else:
-            it = ctbl.where(self.expression, outcols=self.outcols, skip=self.skip,
+            it = ctbl.where(self.expression, outcols=self.outcols, skip=self._skip,
                            limit=self.limit)
 
         for row in it:

--- a/petl/test/test_method_shadow.py
+++ b/petl/test/test_method_shadow.py
@@ -1,15 +1,21 @@
 """
-Regression tests for Table subclasses whose stored ``header`` argument
-shadowed the inherited ``Table.header()`` method, so calling the fluent
-``.header()`` raised ``TypeError: '...' object is not callable``.
+Regression tests for Table subclasses that store a constructor argument
+under a name the fluent API already binds on ``Table``. The instance
+attribute wins attribute lookup, so the method becomes unreachable and
+calling it raises ``TypeError: '...' object is not callable``.
 
-See issue #555 (fixed the same collision on ``fromdicts``) and PR #697.
+Collisions found so far: ``header`` (issue #555, PR #704), ``dicts``
+(issue #643, PR #697), and ``cache``, ``complement``, ``index``, ``skip``.
+``test_no_shadowed_api_names`` scans the source for new ones.
 """
 
 from __future__ import absolute_import, print_function, division
 
 
+import ast
 import json as _json
+import os
+from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 
 
@@ -19,6 +25,7 @@ import pytest
 import petl as etl
 from petl.compat import PY2
 from petl.test.helpers import eq_
+from petl.util.base import Table
 
 
 def _csvfile(text):
@@ -121,3 +128,244 @@ def test_method_matches_function_form():
     # the fluent method must agree with the etl.header() function
     t = etl.fromcolumns([[1, 2]], ['a'])
     eq_(etl.header(t), t.header())
+
+
+TABLE = [['foo', 'bar'],
+         ['a', 1],
+         ['b', 2]]
+
+RIGHT = [['foo', 'baz'],
+         ['a', True],
+         ['b', False]]
+
+SUBSET = [['foo', 'bar'],
+          ['b', 2]]
+
+
+def test_hashjoin_cache():
+    t = etl.hashjoin(TABLE, RIGHT, key='foo')
+    eq_([('foo', 'bar', 'baz'), ('a', 1, True), ('b', 2, False)],
+        list(t.cache()))
+
+
+def test_hashleftjoin_cache():
+    t = etl.hashleftjoin(TABLE, [['foo', 'baz'], ['a', True]], key='foo')
+    eq_([('foo', 'bar', 'baz'), ('a', 1, True), ('b', 2, None)],
+        list(t.cache()))
+
+
+def test_hashrightjoin_cache():
+    t = etl.hashrightjoin([['foo', 'baz'], ['a', True]], TABLE, key='foo')
+    eq_([('foo', 'baz', 'bar'), ('a', True, 1), ('b', None, 2)],
+        list(t.cache()))
+
+
+def test_sort_cache():
+    t = etl.sort(TABLE, 'foo', reverse=True)
+    eq_([('foo', 'bar'), ('b', 2), ('a', 1)], list(t.cache()))
+
+
+def test_cache_cache():
+    t = etl.wrap(TABLE).cache()
+    eq_([('foo', 'bar'), ('a', 1), ('b', 2)],
+        [tuple(row) for row in t.cache()])
+
+
+def test_search_complement():
+    t = etl.search(TABLE, 'a|b')
+    eq_([('foo', 'bar'), ('a', 1)], list(t.complement(SUBSET)))
+
+
+def test_rowselect_complement():
+    t = etl.select(TABLE, lambda row: True)
+    eq_([('foo', 'bar'), ('a', 1)], list(t.complement(SUBSET)))
+
+
+def test_fieldselect_complement():
+    t = etl.select(TABLE, 'foo', lambda v: True)
+    eq_([('foo', 'bar'), ('a', 1)], list(t.complement(SUBSET)))
+
+
+def test_addfield_index():
+    t = etl.addfield(TABLE, 'baz', True)
+    eq_([('foo', 'bar', 'baz'), ('a', 1, True), ('b', 2, True)], list(t))
+    eq_(1, t.index(('a', 1, True)))
+
+
+def test_movefield_index():
+    t = etl.movefield(TABLE, 'bar', 0)
+    eq_([('bar', 'foo'), (1, 'a'), (2, 'b')], list(t))
+    eq_(1, t.index((1, 'a')))
+
+
+# fromavro/frombcolz need optional dependencies for a full round trip, so
+# feed the readers directly instead of installing fastavro and bcolz here.
+
+class _FakeCtable(object):
+
+    names = ('foo', 'bar')
+
+    def iter(self, outcols=None, skip=0, limit=None):
+        return iter([('a', 1), ('b', 2), ('c', 3)][skip:])
+
+
+def test_fromavro_skip():
+    view = etl.fromavro('nonexistent.avro', skips=2)
+    assert isinstance(view.skip(1), Table)
+    # ordered so the row order does not rely on dict iteration order
+    records = [OrderedDict([('foo', v), ('bar', i)])
+               for i, v in enumerate(['a', 'b', 'c'], 1)]
+    eq_([('c', 3)],
+        list(view._read_rows_from(records, ('foo', 'bar'))))
+
+
+def test_frombcolz_skip():
+    view = etl.frombcolz(_FakeCtable(), skip=1)
+    eq_([('foo', 'bar'), ('b', 2), ('c', 3)], list(view))
+    # Table.skip() drops leading rows, so the next row becomes the header
+    eq_([('b', 2), ('c', 3)], list(view.skip(1)))
+
+
+# The renamed attributes are still read internally, so check the options they
+# carry keep working.
+
+def test_hashjoin_cache_option_still_honoured():
+    right = etl.wrap([['foo', 'baz'], ['a', True], ['b', False]])
+    cached = etl.hashjoin(TABLE, right, key='foo')
+    list(cached)
+    assert cached.rlookup is not None
+    uncached = etl.hashjoin(TABLE, right, key='foo', cache=False)
+    list(uncached)
+    first = uncached.rlookup
+    list(uncached)
+    assert uncached.rlookup is not first
+
+
+def test_sort_cache_option_still_honoured():
+    cached = etl.sort(TABLE, 'foo')
+    list(cached)
+    assert cached._memcache is not None
+    uncached = etl.sort(TABLE, 'foo', cache=False)
+    list(uncached)
+    assert uncached._memcache is None
+
+
+def test_cacheview_clearcache_still_works():
+    t = etl.wrap(TABLE).cache()
+    eq_(3, len(list(t)))
+    assert t.cachecomplete
+    t.clearcache()
+    assert not t.cachecomplete
+    eq_(3, len(list(t)))
+
+
+def test_search_complement_option_still_honoured():
+    eq_([('foo', 'bar'), ('a', 1)], list(etl.search(TABLE, 'a')))
+    eq_([('foo', 'bar'), ('b', 2)],
+        list(etl.search(TABLE, 'a', complement=True)))
+
+
+def test_select_complement_option_still_honoured():
+    eq_([('foo', 'bar'), ('b', 2)],
+        list(etl.select(TABLE, lambda row: row.foo == 'a', complement=True)))
+    eq_([('foo', 'bar'), ('b', 2)],
+        list(etl.select(TABLE, 'foo', lambda v: v == 'a', complement=True)))
+
+
+def test_addfield_index_option_still_honoured():
+    eq_([('baz', 'foo', 'bar'), (True, 'a', 1), (True, 'b', 2)],
+        list(etl.addfield(TABLE, 'baz', True, index=0)))
+
+
+def test_movefield_index_option_still_honoured():
+    eq_([('bar', 'foo'), (1, 'a'), (2, 'b')],
+        list(etl.movefield(TABLE, 'bar', 0)))
+
+
+def _class_level_names(node):
+    """Names bound in a class body, which legitimately override the API."""
+    names = set()
+    for stmt in node.body:
+        if isinstance(stmt, ast.FunctionDef):
+            names.add(stmt.name)
+        elif isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+    return names
+
+
+def _self_assignments(node):
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Assign):
+            continue
+        for target in child.targets:
+            if (isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == 'self'):
+                yield target.attr, child.lineno
+
+
+def test_no_shadowed_api_names():
+    """No Table subclass may store an instance attribute named after a
+    method of the fluent API, because the attribute hides the method."""
+    api = set(name for name in dir(Table)
+              if not name.startswith('__') and callable(getattr(Table, name)))
+    assert 'header' in api and 'cache' in api and len(api) > 100
+
+    root = os.path.dirname(os.path.abspath(etl.__file__))
+    classes = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        if 'test' in dirnames:
+            dirnames.remove('test')  # do not scan the suite itself
+        for filename in sorted(filenames):
+            if not filename.endswith('.py'):
+                continue
+            path = os.path.join(dirpath, filename)
+            # read bytes so the parser applies each module's own coding
+            # declaration rather than the platform default encoding
+            with open(path, 'rb') as f:
+                source = f.read()
+            try:
+                tree = ast.parse(source)
+            except SyntaxError:
+                continue  # the py2-only and py3-only modules
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef):
+                    classes.setdefault(node.name, []).append((path, node))
+    assert 'CacheView' in classes and 'SortView' in classes
+
+    def bases(name, seen):
+        if name in seen:
+            return
+        seen.add(name)
+        for _, node in classes.get(name, []):
+            for base in node.bases:
+                if isinstance(base, ast.Name):
+                    yield base.id
+                    for parent in bases(base.id, seen):
+                        yield parent
+                elif isinstance(base, ast.Attribute):
+                    yield base.attr
+
+    offenders = []
+    for name, defs in sorted(classes.items()):
+        ancestors = set(bases(name, set()))
+        if not ancestors & set(['Table', 'IterContainer']):
+            continue
+        # a name redefined in the view itself (or in an intermediate view it
+        # inherits from) is a deliberate override; the base classes are where
+        # the shadowed methods come from, so they do not count
+        overridden = set()
+        for _, node in defs:
+            overridden |= _class_level_names(node)
+        for ancestor in ancestors - set(['Table', 'IterContainer']):
+            for _, node in classes.get(ancestor, []):
+                overridden |= _class_level_names(node)
+        for path, node in defs:
+            for attr, lineno in _self_assignments(node):
+                if attr in api and attr not in overridden:
+                    offenders.append('%s:%s: %s.%s shadows Table.%s()'
+                                     % (os.path.relpath(path, root), lineno,
+                                        name, attr, attr))
+    assert not offenders, '\n'.join(offenders)

--- a/petl/transform/basics.py
+++ b/petl/transform/basics.py
@@ -534,10 +534,10 @@ class AddFieldView(Table):
         self.source = stack(source, missing=missing)
         self.field = field
         self.value = value
-        self.index = index
+        self._index = index
 
     def __iter__(self):
-        return iteraddfield(self.source, self.field, self.value, self.index)
+        return iteraddfield(self.source, self.field, self.value, self._index)
 
 
 def iteraddfield(source, field, value, index):
@@ -928,7 +928,7 @@ class MoveFieldView(Table):
     def __init__(self, table, field, index, missing=None):
         self.table = table
         self.field = field
-        self.index = index
+        self._index = index
         self.missing = missing
 
     def __iter__(self):
@@ -940,7 +940,7 @@ class MoveFieldView(Table):
         except StopIteration:
             hdr = []
         outhdr = [f for f in hdr if f != self.field]
-        outhdr.insert(self.index, self.field)
+        outhdr.insert(self._index, self.field)
         yield tuple(outhdr)
 
         # define a function to transform each row in the source data

--- a/petl/transform/hashjoins.py
+++ b/petl/transform/hashjoins.py
@@ -47,13 +47,13 @@ class HashJoinView(Table):
         self.right = stack(right, missing=missing)
         self.lkey = lkey
         self.rkey = rkey
-        self.cache = cache
+        self._cache = cache
         self.rlookup = None
         self.lprefix = lprefix
         self.rprefix = rprefix
         
     def __iter__(self):
-        if not self.cache or self.rlookup is None:
+        if not self._cache or self.rlookup is None:
             self.rlookup = lookup(self.right, self.rkey)
         return iterhashjoin(self.left, self.right, self.lkey, self.rkey,
                             self.rlookup, self.lprefix, self.rprefix)
@@ -146,13 +146,13 @@ class HashLeftJoinView(Table):
         self.lkey = lkey
         self.rkey = rkey
         self.missing = missing
-        self.cache = cache
+        self._cache = cache
         self.rlookup = None
         self.lprefix = lprefix
         self.rprefix = rprefix
 
     def __iter__(self):
-        if not self.cache or self.rlookup is None:
+        if not self._cache or self.rlookup is None:
             self.rlookup = lookup(self.right, self.rkey)
         return iterhashleftjoin(self.left, self.right, self.lkey, self.rkey,
                                 self.missing, self.rlookup, self.lprefix,
@@ -252,13 +252,13 @@ class HashRightJoinView(Table):
         self.lkey = lkey
         self.rkey = rkey
         self.missing = missing
-        self.cache = cache
+        self._cache = cache
         self.llookup = None
         self.lprefix = lprefix
         self.rprefix = rprefix
 
     def __iter__(self):
-        if not self.cache or self.llookup is None:
+        if not self._cache or self.llookup is None:
             self.llookup = lookup(self.left, self.lkey)
         return iterhashrightjoin(self.left, self.right, self.lkey, self.rkey,
                                  self.missing, self.llookup, self.lprefix,

--- a/petl/transform/regex.py
+++ b/petl/transform/regex.py
@@ -309,11 +309,11 @@ class SearchView(Table):
         self.pattern = pattern
         self.field = field
         self.flags = flags
-        self.complement = complement
+        self._complement = complement
 
     def __iter__(self):
         return itersearch(self.table, self.pattern, self.field, self.flags,
-                          self.complement)
+                          self._complement)
 
 
 def itersearch(table, pattern, field, flags, complement):

--- a/petl/transform/selects.py
+++ b/petl/transform/selects.py
@@ -93,11 +93,11 @@ class RowSelectView(Table):
         self.source = source
         self.where = where
         self.missing = missing
-        self.complement = complement
+        self._complement = complement
 
     def __iter__(self):
         return iterrowselect(self.source, self.where, self.missing,
-                             self.complement)
+                             self._complement)
 
 
 class FieldSelectView(Table):
@@ -106,12 +106,12 @@ class FieldSelectView(Table):
         self.source = source
         self.field = field
         self.where = where
-        self.complement = complement
+        self._complement = complement
         self.missing = missing
 
     def __iter__(self):
         return iterfieldselect(self.source, self.field, self.where,
-                               self.complement, self.missing)
+                               self._complement, self.missing)
 
 
 def iterfieldselect(source, field, where, complement, missing):

--- a/petl/transform/sorts.py
+++ b/petl/transform/sorts.py
@@ -229,7 +229,7 @@ class SortView(Table):
         else:
             self.buffersize = buffersize
         self.tempdir = tempdir
-        self.cache = cache
+        self._cache = cache
         self._hdrcache = None
         self._memcache = None
         self._filecache = None
@@ -246,9 +246,9 @@ class SortView(Table):
         source = self.source
         key = self.key
         reverse = self.reverse
-        if self.cache and self._memcache is not None:
+        if self._cache and self._memcache is not None:
             return self._iterfrommemcache()
-        elif self.cache and self._filecache is not None:
+        elif self._cache and self._filecache is not None:
             return self._iterfromfilecache()
         else:
             return self._iternocache(source, key, reverse)
@@ -312,7 +312,7 @@ class SortView(Table):
         if self.buffersize is None or len(rows) < self.buffersize:
             # yes, table fits within sort buffer
 
-            if self.cache:
+            if self._cache:
                 debug('caching mem')
                 self._hdrcache = hdr
                 self._memcache = rows
@@ -348,7 +348,7 @@ class SortView(Table):
                 rows = list(itertools.islice(it, 0, self.buffersize))
                 rows.sort(key=getkey, reverse=reverse)
 
-            if self.cache:
+            if self._cache:
                 debug('caching files')
                 self._hdrcache = hdr
                 self._filecache = chunkfiles

--- a/petl/util/materialise.py
+++ b/petl/util/materialise.py
@@ -143,29 +143,29 @@ class CacheView(Table):
     def __init__(self, inner, n=None):
         self.inner = inner
         self.n = n
-        self.cache = list()
+        self._cache = list()
         self.cachecomplete = False
 
     def clearcache(self):
-        self.cache = list()
+        self._cache = list()
         self.cachecomplete = False
 
     def __iter__(self):
 
         # serve whatever is in the cache first
-        for row in self.cache:
+        for row in self._cache:
             yield row
 
         if not self.cachecomplete:
 
             # serve the remainder from the inner iterator
             it = iter(self.inner)
-            for row in islice(it, len(self.cache), None):
+            for row in islice(it, len(self._cache), None):
                 # maybe there's more room in the cache?
-                if not self.n or len(self.cache) < self.n:
-                    self.cache.append(row)
+                if not self.n or len(self._cache) < self.n:
+                    self._cache.append(row)
                 yield row
 
             # does the cache contain a complete copy of the inner table?
-            if not self.n or len(self.cache) < self.n:
+            if not self.n or len(self._cache) < self.n:
                 self.cachecomplete = True


### PR DESCRIPTION
Follow-up to #697 and #704, finishing the same collision class.

## The class

`Table` gets most of its fluent API from module-level assignments
(`Table.cache = cache`, `Table.complement = complement`, `Table.skip = skip`)
plus the methods it inherits from `IterContainer` (`index`, `min`, `list`, ...) —
263 callables in total. Views then store their constructor arguments as instance
attributes of the same name. Python resolves the instance attribute first, so the
method is gone and calling it raises `TypeError`:

```python
>>> import petl as etl
>>> etl.sort([['foo'], ['a']], 'foo').cache()
TypeError: 'bool' object is not callable
>>> etl.select([['foo'], ['a']], lambda row: True).complement([['foo']])
TypeError: 'bool' object is not callable
>>> etl.addfield([['foo'], ['a']], 'bar', 1).index(('a', 1))
TypeError: 'NoneType' object is not callable
```

5498411 (#555) hit this on `header`, #697 on `dicts`, #704 on the remaining
thirteen `header` sites. I went back over the whole surface rather than the one
call I tripped over, by intersecting the 263-name API with every `self.<name> =`
assignment in a `Table` subclass. Twelve views were still affected:

| method | view | file |
|---|---|---|
| `cache()` | `HashJoinView` | `transform/hashjoins.py` |
| `cache()` | `HashLeftJoinView` | `transform/hashjoins.py` |
| `cache()` | `HashRightJoinView` | `transform/hashjoins.py` |
| `cache()` | `SortView` | `transform/sorts.py` |
| `cache()` | `CacheView` | `util/materialise.py` |
| `complement()` | `SearchView` | `transform/regex.py` |
| `complement()` | `RowSelectView` | `transform/selects.py` |
| `complement()` | `FieldSelectView` | `transform/selects.py` |
| `index()` | `AddFieldView` | `transform/basics.py` |
| `index()` | `MoveFieldView` | `transform/basics.py` |
| `skip()` | `AvroView` | `io/avro.py` |
| `skip()` | `BcolzView` | `io/bcolz.py` |

All twelve raise today; all twelve pass after the change, and the scan now comes
back empty.

## The fix

Rename the stored attribute with a leading underscore, the convention 5498411
introduced for `header` and #697 followed for `dicts`.

The compatibility question that came up on #697 does not arise here. `.dicts` was
the caller's own input data, so that PR kept it readable through a property. These
twelve are internal flags and offsets (`cache=True`, `complement=False`, `index=0`,
`skip=0`) — nothing in the docs, examples or tests reads them back off a view, and
`grep` finds no reader outside the class that owns them. So a plain rename, no shim.

I also looked at fixing this at the root, in `Table` itself: a `__setattr__` that
refuses to store an attribute shadowing a method would catch the whole class
permanently. It would put a Python-level call on every attribute write in every
view for a problem that only bites at construction time, and it would break any
downstream subclass doing the same thing. Not worth it — a test can do the same
job for free.

## Tests

`test_method_shadow.py` grows from the thirteen `header` cases to cover the four
new names: one test per view calling the method that used to raise, plus tests
that the renamed attributes still carry their options (`cache=False` really
disables caching, `complement=True` really inverts the selection, `index=0` really
positions the field, `skip=n` really skips). `fromavro`/`frombcolz` are driven
without fastavro and bcolz installed, since neither is needed to reach the
skipping code.

`test_no_shadowed_api_names` is the one that matters: it walks the package,
finds every `Table` subclass, and fails if any of them assigns an instance
attribute named after an API method — reporting file, line, class and name. It
reproduces all twelve sites on master and would have caught #555, #643 and #704
as well. A deliberate class-level override (`DictsView.dicts`, the property #697
added) is not flagged.

586 pass, 13 skip; `pytest --doctest-modules` 739 pass, 21 skip. I mutated each
renamed read in both directions — leaving a site shadowed, and dropping or
inverting the option the attribute carries — and every mutant is caught.
