### PR TITLE
Fix avro decimal precision and scale inferred from Decimal values

### DIFF
--- a/petl/io/avro.py
+++ b/petl/io/avro.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
-import math
 from collections import OrderedDict
 from datetime import datetime, date, time
 from decimal import Decimal
@@ -481,30 +480,48 @@ def _get_precision_from_decimal(curr, val, prev):
     else:
         prec, scale, _, _ = precision_and_scale(val)
     if prev is not None:
-        # get the greatests precision and scale of the sample
+        # the schema has to hold the greatest integer part and the greatest
+        # scale of the sample, so combine those before adding them back up:
+        # a value is rescaled to the scale of the schema when written, which
+        # widens its unscaled integer by the difference between both scales
         prec0, scale0 = prev.get('precision'), prev.get('scale')
-        prec, scale = max(prec, prec0), max(scale, scale0)
-    prec = max(prec, 8)
+        int_digits = max(prec - scale, prec0 - scale0)
+        scale = max(scale, scale0)
+        prec = int_digits + scale
     curr = {'precision': prec, 'scale': scale, }
-    return curr, prec, scale
+    # leave some room for the values coming after the sample, but keep the
+    # running estimate free of it so that it does not accumulate
+    return curr, max(prec, 8), scale
 
 
 def precision_and_scale(numeric_value):
-    sign, digits, exp = numeric_value.as_tuple()
-    number = 0
-    for digit in digits:
-        number = (number * 10) + digit
-    # delta = exp + scale
-    delta = 1
-    number = 10 ** delta * number
-    inumber = int(number)
+    '''get the avro decimal logicalType properties of a Decimal value
 
-    bits_req = inumber.bit_length() + 1
-    bytes_req = (bits_req + 8) // 8
+    The avro spec defines a decimal as `unscaled * 10**-scale`, so the scale
+    is the number of fractional digits and the precision is the number of
+    digits of the unscaled integer. The spec also requires the scale to be
+    "zero or a positive integer less than or equal to the precision".
+    '''
+    if not numeric_value.is_finite():
+        raise ValueError(
+            'cannot build an avro decimal schema for %s: not a finite number'
+            % numeric_value)
+    sign, digits, exp = numeric_value.as_tuple()
+    # a positive exponent means trailing zeros, not fractional digits
+    scale = -exp if exp < 0 else 0
+    # the unscaled integer spans the integer part plus the fractional digits
+    int_digits = len(digits) + exp
+    prec = max(int_digits + scale, scale, 1)
+
+    inumber = 0
+    for digit in digits:
+        inumber = (inumber * 10) + digit
+    if exp > 0:
+        # scale is 0 here, so the trailing zeros belong in the unscaled int
+        inumber *= 10 ** exp
+    bytes_req = (inumber.bit_length() + 8) // 8
     if sign:
         inumber = - inumber
-    prec = int(math.ceil(math.log10(abs(inumber))))
-    scale = abs(exp)
     return prec, scale, bytes_req, inumber
 
 

--- a/petl/test/io/test_avro.py
+++ b/petl/test/io/test_avro.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import, print_function, division
 
 import math
 
+from collections import OrderedDict
 from datetime import datetime, date
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -17,6 +18,7 @@ from petl.util.vis import look
 from petl.test.helpers import ieq
 
 from petl.io.avro import fromavro, toavro, appendavro
+from petl.io.avro import _get_definition_from_type_of, precision_and_scale
 
 from petl.test.io.test_avro_schemas import schema0, schema1, schema2, \
     schema3, schema4, schema5, schema6
@@ -128,6 +130,99 @@ else:
 
     # endregion
 
+    # region Decimal schema inference
+
+    def test_toavro_decimal_zero():
+        # a zero has no digits to take the logarithm of
+        _write_to_avro_file(table_dec_zero, None)
+        _assert_decimal_type(table_dec_zero, 8, 2)
+
+    def test_toavro_decimal_small():
+        # more fractional digits than the default precision of 8
+        _write_to_avro_file(table_dec_small, None)
+        _assert_decimal_type(table_dec_small, 9, 9)
+
+    def test_toavro_decimal_integral():
+        # positive exponents are trailing zeros, not fractional digits
+        _write_to_avro_file(table_dec_integral, None)
+        _assert_decimal_type(table_dec_integral, 8, 0)
+
+    def test_toavro_decimal_mixed_scales():
+        # writing rescales a value to the scale of the schema, so the
+        # precision has to cover the widest unscaled integer of the column
+        _write_to_avro_file(table_dec_mixed, None)
+        _assert_decimal_type(table_dec_mixed, 20, 11)
+
+    def test_toavro_decimal_nested():
+        # arrays and records reach the same inference helper
+        _write_to_avro_file(table_dec_nested, None)
+
+    def test_precision_and_scale_of_each_shape():
+        for value, prec, scale in decimal_shapes:
+            actual = precision_and_scale(value)[:2]
+            assert actual == (prec, scale), \
+                'precision_and_scale(%s): got %r, expected %r' \
+                % (value, actual, (prec, scale))
+
+    def test_inferred_decimal_type_obeys_avro_spec():
+        # the spec asks for a precision "greater than zero" and a scale
+        # "zero or a positive integer less than or equal to the precision"
+        for column in _all_decimal_columns():
+            prec, scale = _infer_decimal_type(column)
+            assert prec > 0, \
+                'column %r got precision %d' % (_labels(column), prec)
+            assert 0 <= scale <= prec, \
+                'column %r got scale %d > precision %d' \
+                % (_labels(column), scale, prec)
+
+    def test_inferred_decimal_type_fits_every_value():
+        # a decimal is `unscaled * 10 ** -scale`, so at the scale of the
+        # schema each value must stay within the declared precision
+        for column in _all_decimal_columns():
+            prec, scale = _infer_decimal_type(column)
+            for value in column:
+                if value is None:
+                    continue
+                digits = _unscaled_digits(value, scale)
+                assert digits <= prec, \
+                    'column %r: %s needs %d digits, precision is %d' \
+                    % (_labels(column), value, digits, prec)
+
+    def test_precision_and_scale_of_unscaled_value():
+        for value, _, _ in decimal_shapes:
+            _, scale, bytes_req, unscaled = precision_and_scale(value)
+            assert (unscaled < 0) == (value < 0), \
+                '%s came back as %d' % (value, unscaled)
+            # the defining identity: unscaled * 10**-scale must equal value,
+            # trailing zeros included (a plain digit-string compare doesn't
+            # catch a positive-exponent value coming back short of them);
+            # a wide context avoids scaleb rounding the widest fixtures
+            with localcontext() as ctx:
+                ctx.prec = 60
+                assert Decimal(unscaled).scaleb(-scale) == value, \
+                    '%s came back as %d at scale %d' % (value, unscaled, scale)
+            assert _significand('{0:f}'.format(value)) \
+                == _significand('%d' % unscaled), \
+                '%s came back as %d' % (value, unscaled)
+            # enough room for the two's complement of the unscaled integer
+            assert 2 ** (8 * bytes_req - 1) > abs(unscaled), \
+                '%s needs more than %d bytes' % (value, bytes_req)
+            assert bytes_req == 1 or 2 ** (8 * bytes_req - 9) <= abs(unscaled), \
+                '%s does not need %d bytes' % (value, bytes_req)
+
+    def test_precision_and_scale_of_non_finite():
+        for value in [Decimal('NaN'), Decimal('Infinity'), Decimal('-Inf')]:
+            try:
+                precision_and_scale(value)
+            except ValueError as vex:
+                # the message has to name the value that cannot be written
+                assert str(value) in '%s' % vex, \
+                    '%s is not reported by: %s' % (value, vex)
+                continue
+            assert False, 'built a decimal schema for %s' % value
+
+    # endregion
+
     # region Execution
 
     def _read_from_mavro_file(test_rows, test_schema, test_expect=None, print_tables=True):
@@ -187,6 +282,51 @@ else:
 
     def _decs(float_value, rounding=12):
         return Decimal(str(round(float_value, rounding)))
+
+    def _assert_decimal_type(test_rows, prec, scale):
+        column = [row[1] for row in test_rows[1:]]
+        actual = _infer_decimal_type(column)
+        assert actual == (prec, scale), \
+            'column %r got %r, expected %r' \
+            % (_labels(column), actual, (prec, scale))
+
+    def _all_decimal_columns():
+        return [[value] for value, _, _ in decimal_shapes] + decimal_columns
+
+    def _labels(column):
+        return [str(value) for value in column]
+
+    def _infer_decimal_type(column):
+        '''the precision and scale petl infers for a column of decimals'''
+        prev = None
+        tdef = None
+        for value in column:
+            curr, dcurr = _get_definition_from_type_of(u'amount', value, prev)
+            # a None row leaves the definition built so far untouched
+            if curr is not None:
+                tdef = curr
+            if dcurr is not None:
+                prev = dcurr
+        return tdef['precision'], tdef['scale']
+
+    def _significand(text):
+        '''the digits of a number, without sign, point or padding zeros'''
+        return text.replace('-', '').replace('.', '').strip('0')
+
+    def _unscaled_digits(value, scale):
+        '''digit count of `value * 10 ** scale`, taken from its text form
+
+        Deliberately built from the fixed point representation instead of
+        `Decimal.as_tuple()`, which is what the code under test reads, and
+        without arithmetic, which would round on the decimal context.
+        '''
+        fixed = '{0:f}'.format(value)
+        fraction = fixed.split('.')[1] if '.' in fixed else ''
+        assert len(fraction) <= scale, \
+            '%s does not fit a scale of %d' % (value, scale)
+        text = fixed.replace('-', '').replace('.', '')
+        text = text + '0' * (scale - len(fraction))
+        return len(text.lstrip('0')) or 1
 
     def _utc(year, month, day, hour=0, minute=0, second=0, microsecond=0):
         u = datetime(year, month, day, hour, minute, second, microsecond)
@@ -328,6 +468,87 @@ else:
              [2, { u'name': u'Joe', u'alias': u'terminator' }]]
 
     table9 = [header8] + rows9
+
+    # (value, precision, scale) of the avro decimal logicalType, where the
+    # precision is the digit count of the unscaled integer and the scale the
+    # count of fractional digits
+    decimal_shapes = [
+        # zeros, in every shape Decimal can hold one
+        (Decimal('0'), 1, 0),
+        (Decimal('-0'), 1, 0),
+        (Decimal('0.0'), 1, 1),
+        (Decimal('0.00'), 2, 2),
+        # a zero keeps the width implied by its own exponent
+        (Decimal('0E+2'), 3, 0),
+        (Decimal('0E-7'), 7, 7),
+        # integers, including the exact powers of ten
+        (Decimal('1'), 1, 0),
+        (Decimal('42'), 2, 0),
+        (Decimal('-99'), 2, 0),
+        (Decimal('10'), 2, 0),
+        (Decimal('100'), 3, 0),
+        (Decimal('12345'), 5, 0),
+        # ordinary fractions
+        (Decimal('1.5'), 2, 1),
+        (Decimal('99.99'), 4, 2),
+        (Decimal('123.45'), 5, 2),
+        (Decimal('100.00'), 5, 2),
+        (Decimal('-3.14159'), 6, 5),
+        # fewer digits than fractional places
+        (Decimal('0.1'), 1, 1),
+        (Decimal('0.001'), 3, 3),
+        (Decimal('0.00000001'), 8, 8),
+        (Decimal('1E-9'), 9, 9),
+        (Decimal('1E-12'), 12, 12),
+        # positive exponents: trailing zeros are part of the integer
+        (Decimal('1E+2'), 3, 0),
+        (Decimal('1.5E+3'), 4, 0),
+        (Decimal('-2E+5'), 6, 0),
+        (Decimal('1E+20'), 21, 0),
+        # more digits than the decimal context holds by default
+        (Decimal('12345678901234.5678'), 18, 4),
+        (Decimal('0.123456789012345678'), 18, 18),
+        (Decimal('123456789012345678901234567890'), 30, 0),
+    ]
+
+    # columns whose values disagree on scale, precision or both
+    decimal_columns = [
+        [Decimal('0.00'), Decimal('12.34')],
+        [Decimal('1'), Decimal('0'), Decimal('-0'), Decimal('0.00')],
+        [Decimal('1.5'), Decimal('0.001')],
+        [Decimal('123456789.1'), Decimal('0.12345678901')],
+        [Decimal('1E-12'), Decimal('1.5')],
+        [Decimal('0.001'), Decimal('1E-12')],
+        [Decimal('1E+7'), Decimal('0.5')],
+        [Decimal('9.99'), Decimal('1E-9'), Decimal('123456.789')],
+        [Decimal('1E+20'), Decimal('0.000001')],
+        [Decimal('0.5'), Decimal('1E+2'), Decimal('1E-8')],
+        [Decimal('1.100'), None, Decimal('0')],
+    ]
+
+    header_dec = [u'name', u'amount']
+
+    table_dec_zero = [header_dec,
+                      [u'pete', Decimal('0.00')],
+                      [u'mike', Decimal('12.34')],
+                      [u'zack', Decimal('-0')]]
+
+    table_dec_small = [header_dec,
+                       [u'pete', Decimal('1E-9')],
+                       [u'mike', Decimal('0.000000025')]]
+
+    table_dec_integral = [header_dec,
+                          [u'pete', Decimal('1E+2')],
+                          [u'mike', Decimal('-2E+5')]]
+
+    table_dec_mixed = [header_dec,
+                       [u'pete', Decimal('123456789.1')],
+                       [u'mike', Decimal('0.12345678901')]]
+
+    table_dec_nested = [[u'name', u'amounts', u'totals'],
+                        [u'pete', [Decimal('0.00'), Decimal('1E-9')],
+                         OrderedDict([(u'due', Decimal('0')),
+                                      (u'paid', Decimal('1E+2'))])]]
 
     # endregion
 


### PR DESCRIPTION
`toavro()` without an explicit schema infers a `decimal` logicalType for every `Decimal`
column, and `precision_and_scale()` derives its `precision`/`scale`. A zero-valued Decimal
crashes it:

```python
from decimal import Decimal
import petl as etl

etl.toavro([['id', 'amount'],
            [1, Decimal('0.00')],
            [2, Decimal('12.34')]], 'out.avro')
```

```
  File "petl/io/avro.py", line 506, in precision_and_scale
    prec = int(math.ceil(math.log10(abs(inumber))))
ValueError: math domain error
```

## Root cause

`precision_and_scale()` is a copy of fastavro's `prepare_bytes_decimal()` — same `digits`
loop, same `delta`, same `(bit_length + 8) // 8` — but that function is an *encoder*: its
`delta = exp + scale` rescales a value to a scale the schema has already fixed. At inference
time there is no scale yet, so `delta` was hardcoded to `1` and the leftover comment
`# delta = exp + scale` is still there. The digit count is then taken from that rescaled
integer with `ceil(log10(...))`, and the scale from `abs(exp)`.

Four things follow from that, all of them reachable from `toavro()` with no schema, and all
of them equally from a Decimal inside an array or inside a nested record (both recurse
through `_get_definition_from_type_of`):

1. **Every zero crashes.** `Decimal('0')`, `'0.00'`, `'-0'`, `'0E+2'` and any arithmetic
   result that normalises to zero all have `digits == (0,)`, so `inumber` is 0 and
   `log10(0)` raises. A zero balance or a zero quantity is not an edge case.
2. **A scale larger than the precision.** The spec says *"Scale must be zero or a positive
   integer less than or equal to the precision"*, and `precision` is left at the `max(prec, 8)`
   floor for a value with few digits. `Decimal('1E-9')` therefore produces `precision 8,
   scale 9` and fastavro refuses the schema outright:
   `SchemaParseException: decimal scale must be less than or equal to the precision of 8`.
3. **A positive exponent is counted as fractional digits.** `abs(exp)` turns
   `Decimal('1E+2')` — an integer — into `scale 2`. A decimal is `unscaled × 10**-scale`, so
   an integral value has scale 0.
4. **The precision of a column does not cover its own values.** The sample is combined with
   `max(prec), max(scale)` independently, but writing rescales each value *to the scale of
   the schema*, widening its unscaled integer by the difference between the two scales. For
   `[Decimal('123456789.1'), Decimal('0.12345678901')]` the inferred type is
   `precision 12, scale 11`, while the first value needs 20 unscaled digits. fastavro only
   checks `len(digits)` against the precision, so this one is silent — the file is written
   with a declared precision that is a lie about its contents, and a stricter reader is
   entitled to reject it.

## The fix

Count digits from the coefficient and the exponent rather than from a rescaled integer, and
combine the sample on the integer part and the scale separately:

```python
scale = -exp if exp < 0 else 0
int_digits = len(digits) + exp
prec = max(int_digits + scale, scale, 1)
```

This drops `math` from the module. `max(prec, 8)` is kept, but is now applied only to the
emitted precision so it no longer feeds back into the running estimate.

Non finite Decimals (`NaN`, `Infinity`) have no decimal representation under any schema —
fastavro cannot encode them either — and currently die inside the digit count with the same
`math domain error`. They now raise a `ValueError` naming the value.

Values written under an explicit `schema=` are unaffected; this path only runs for inferred
schemas.

## Audit

`math.log10` and this precision/scale derivation appear exactly once in the package, and the
`Decimal` branch is the only branch of `_get_definition_from_type_of` that derives a numeric
*property* rather than a constant type name — so the class is contained in these two
functions. To confirm the fix covers it rather than just the reported symptom, I ran the
inference over 43 columns (every shape a `Decimal` can take, plus mixed-scale columns) and
checked each inferred type against the spec form `unscaled × 10**-scale`, using the
fixed-point text of each value rather than `as_tuple()`, which is what the code under test
reads:

* precision > 0 and `0 <= scale <= precision`;
* every value representable at the inferred scale;
* the unscaled integer of every value within the declared precision.

**21 of 43 columns fail on master** (7 crash, 5 produce a schema fastavro rejects, 9 produce
a schema that under-declares its own data); 0 fail after the change. That audit is what the
two sweep tests in this PR do.

## Tests

`petl/test/io/test_avro.py` gains 10 tests: the four end-to-end repros (zero, sub-8-digit
scale, positive exponent, mixed scales) plus a nested array/record one, a 29-row table of
`(value, precision, scale)`, the two spec sweeps above, coverage for the unscaled value and
byte width that `precision_and_scale()` returns, and the non-finite case. All 10 fail on
master and pass after the change.

Suite: 624 passed / 11 skipped (from 614 / 11); `--doctest-modules` 777 passed / 17 skipped.
flake8 clean on both files. Optional deps missing locally so those modules skip
(sqlalchemy, tables, xlrd, openpyxl, gspread, fsspec, smbclient, the DB servers); the avro
module itself needs `pytz` in addition to `fastavro`, which is only pulled in transitively
by pandas — worth knowing, since without it the whole avro test module skips silently.

I also mutated the fix in both directions — 15 mutants covering each piece of the new digit
count, the sample combination, the precision floor, the sign and the byte width — and every
one of them turns the new tests red, with a no-op reordering as a control.
