### PR TITLE
docs: demonstrate row field-name and index access in convert

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Changes
 Version 1.7.25
 --------------
 
+* docs: demonstrate field-name and index access in row-aware conversions,
+  including column names containing spaces.
+  By :user:`be-student`, :issue:`671`.
 * chore: improve CI/CD workflows, update documentation
   By :user:`juarezr`, :issue:`709`.
 * feat: add truncate argument to todb function

--- a/petl/transform/conversions.py
+++ b/petl/transform/conversions.py
@@ -181,6 +181,34 @@ def convert(table, *args, **kwargs):
     arguments to the conversion function (so, i.e., the conversion function
     should accept two arguments).
 
+    The row supports attribute, field-name and zero-based index access, as
+    described under :func:`petl.util.base.records`. Use field-name access for
+    column names containing spaces or punctuation, which cannot be written
+    as attributes. For example::
+
+        >>> orders = [['Unit Price', 'Quantity', 'Total'],
+        ...           [5, 2, None], [3, 4, None]]
+        >>> totals = etl.convert(orders, 'Total',
+        ...                      lambda value, row: row['Unit Price'] * row['Quantity'],
+        ...                      pass_row=True)
+        >>> list(totals)
+        [('Unit Price', 'Quantity', 'Total'), (5, 2, 10), (3, 4, 12)]
+
+    The same conversion can use indexes instead of field names::
+
+        >>> totals = etl.convert(orders, 'Total',
+        ...                      lambda value, row: row[0] * row[1],
+        ...                      pass_row=True)
+        >>> list(totals)
+        [('Unit Price', 'Quantity', 'Total'), (5, 2, 10), (3, 4, 12)]
+
+    Return the replacement value from the conversion function; the row is a
+    read-only record, so do not assign to ``row['Total']``. The input table
+    remains unchanged::
+
+        >>> orders
+        [['Unit Price', 'Quantity', 'Total'], [5, 2, None], [3, 4, None]]
+
     When multiple fields are converted in a single call, the conversions
     are independent of each other. Each conversion sees the original row::
 


### PR DESCRIPTION
This PR adds the field-name and index examples requested in #671 to the `convert()` documentation, next to `pass_row`.

## Changes

- Demonstrate reading column names containing spaces with `row["Unit Price"]`, and the equivalent zero-based index conversion.
- Explain returning the replacement value instead of mutating the read-only row, and show that the input stays unchanged.
- Link the common `records()` access contract and record the documentation change in `docs/changes.rst`.

The examples are doctests exercised by the existing doctest CI job. Runtime behavior is unchanged.

## Validation

Python 3.12:
- `pytest --doctest-modules petl/transform/conversions.py petl/test/transform/test_conversions.py`: 20 passed.
- `pytest petl`: 541 passed, 17 skipped, 5 warnings. Optional database/format services were not installed.
- `sphinx-build -W -b singlehtml -d ../build/doctrees . ../build/singlehtml` from `docs`: passed.
- `git diff --check`: passed.

## Checklist

- [x] Runnable documentation examples included; no new functions or runtime code.
- [x] Changes documented in `docs/changes.rst`.
- [x] Atomic, reversible change with no generated build artifacts.
- [x] Tested locally against the current `master` checkout.
- [ ] Remote CI passes (pending).
- [ ] Coverage status verified in Coveralls (pending).
- [x] Ready to review.

AI assistance: Codex implemented the documentation and ran the checks listed above.

Fixes #671.
