### PR TITLE
Preserve record metadata across pickle round trips

### DIFF
--- a/petl/test/util/test_base.py
+++ b/petl/test/util/test_base.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, print_function, division
 
+import pickle
+import shelve
+
 import pytest
 
 from petl.errors import FieldSelectionError
@@ -7,6 +10,7 @@ from petl.test.helpers import ieq, eq_
 from petl.compat import PY3, next
 from petl.util.base import header, fieldnames, data, dicts, records, \
     namedtuples, itervalues, values, rowgroupby, expr
+from petl.util.lookups import recordlookup
 
 
 def test_header():
@@ -107,6 +111,47 @@ def test_records():
     eq_(1, o.get('bar'))
     eq_(None, o.get('baz'))
     eq_('qux', o.get('baz', default='qux'))
+
+
+@pytest.mark.parametrize('protocol', range(pickle.HIGHEST_PROTOCOL + 1))
+@pytest.mark.parametrize('row', [('a',), ('a', 1), ('a', 1, True)])
+def test_records_pickle(protocol, row):
+    original = next(iter(records([['foo', 'bar'], row], missing='missing')))
+    original.extra = {'nested': [1, 2]}
+    restored = pickle.loads(pickle.dumps(original, protocol=protocol))
+    eq_(type(original), type(restored))
+    eq_(tuple(original), tuple(restored))
+    eq_(original.flds, restored.flds)
+    eq_(original.missing, restored.missing)
+    eq_(original.extra, restored.extra)
+    eq_(original[0], restored[0])
+    eq_(original['bar'], restored['bar'])
+    eq_(original.bar, restored.bar)
+    with pytest.raises(KeyError):
+        restored['unknown']
+    with pytest.raises(AttributeError):
+        restored.unknown
+
+
+def test_records_legacy_pickle():
+    # Protocol 0 output produced before Record defined its own reducer.
+    payload = (b'ccopy_reg\n_reconstructor\np0\n(cpetl.util.base\nRecord\np1\n'
+               b'c__builtin__\ntuple\np2\n(Va\np3\ntp4\ntp5\nRp6\n(dp7\n'
+               b'Vflds\np8\n(lp9\nVfoo\np10\naVbar\np11\nasVmissing\np12\ng12\nsb.')
+    restored = pickle.loads(payload)
+    eq_(('a',), tuple(restored))
+    eq_('a', restored.foo)
+    eq_('missing', restored.bar)
+
+
+def test_recordlookup_shelve(tmpdir):
+    filename = str(tmpdir.join('records'))
+    table = [['foo', 'bar'], ['a', 1], ['a', 2]]
+    with shelve.open(filename) as database:
+        recordlookup(table, 'foo', dictionary=database)
+    with shelve.open(filename) as database:
+        eq_([1, 2], [record.bar for record in database['a']])
+        eq_(['a', 'a'], [record['foo'] for record in database['a']])
 
 
 def test_records_headerless():

--- a/petl/test/util/test_base.py
+++ b/petl/test/util/test_base.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 import pickle
 import shelve
+from contextlib import closing
 
 import pytest
 
@@ -147,9 +148,9 @@ def test_records_legacy_pickle():
 def test_recordlookup_shelve(tmpdir):
     filename = str(tmpdir.join('records'))
     table = [['foo', 'bar'], ['a', 1], ['a', 2]]
-    with shelve.open(filename) as database:
+    with closing(shelve.open(filename)) as database:
         recordlookup(table, 'foo', dictionary=database)
-    with shelve.open(filename) as database:
+    with closing(shelve.open(filename)) as database:
         eq_([1, 2], [record.bar for record in database['a']])
         eq_(['a', 'a'], [record['foo'] for record in database['a']])
 

--- a/petl/util/base.py
+++ b/petl/util/base.py
@@ -565,6 +565,9 @@ class Record(tuple):
         self.flds = flds
         self.missing = missing
 
+    def __reduce__(self):
+        return type(self), (tuple(self), self.flds, self.missing), self.__dict__
+
     def __getitem__(self, f):
         if isinstance(f, int):
             idx = f
@@ -579,14 +582,16 @@ class Record(tuple):
             return self.missing
 
     def __getattr__(self, f):
-        if f in self.flds:
+        # Unpickling older records can probe attributes before restoring flds.
+        flds = object.__getattribute__(self, 'flds')
+        if f in flds:
             try:
-                return super(Record, self).__getitem__(self.flds.index(f))
+                return super(Record, self).__getitem__(flds.index(f))
             except IndexError:  # handle short rows
                 return self.missing
         else:
             raise AttributeError('item ' + repr(f) +
-                                ' not in fields ' + repr(self.flds))
+                                ' not in fields ' + repr(flds))
 
     def get(self, key, default=None):
         try:
@@ -618,6 +623,10 @@ def records(table, *sliceargs, **kwargs):
         ['a', 'b']
 
     Short rows are padded with the value of the `missing` keyword argument.
+
+    Records can be pickled when their values and metadata are picklable.
+    Field names and the `missing` value are retained after loading, so field
+    access behaves the same as before serialization.
 
     """
 


### PR DESCRIPTION
Fixes #299.

`Record` needs field names when reconstructed, but tuple's default pickle path does not supply them. Older pickle protocols also probe attributes before field metadata is restored, causing recursive `__getattr__` calls. Define the record reconstruction arguments and preserve instance state; access field metadata directly when resolving attributes so older protocol-0 data can be restored.

The normal test suite now covers all available pickle protocols, short/full/extended rows, named and positional access, missing values, extra metadata, older serialized data, and a real `recordlookup()` round trip through a closed and reopened `shelve` database. Document the serialization contract in `records()`.

Validation: 19 new round-trip/shelve cases failed before the fix, and the additional legacy fixture exposed the attribute recursion. The final utility/transform suite passes: 374 tests, 1 skipped. Sphinx HTML builds with warnings treated as errors. External database/remote filesystem tests were not run.
