### PR TITLE
Raise explicit argument errors for invalid recast fields

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Unreleased
+----------
+
+* Raise ``ArgumentError`` for invalid ``recast()`` fields, including under
+  Python optimization, instead of relying on assertions. See :issue:`297`.
+
 Version 1.7.25
 --------------
 

--- a/petl/test/transform/test_reshape.py
+++ b/petl/test/transform/test_reshape.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import, print_function, division
 
 
 from datetime import datetime
+import subprocess
+import sys
 
 import pytest
 
-from petl.errors import FieldSelectionError
+from petl.errors import ArgumentError, FieldSelectionError
 from petl.test.helpers import ieq
 from petl.transform.reshape import melt, recast, transpose, pivot, flatten, \
     unflatten
@@ -485,3 +487,38 @@ def test_unflatten_empty():
     expect1 = (('f0', 'f1', 'f2'),)
     actual1 = unflatten(table1, 'lines', 3)
     ieq(expect1, actual1)
+
+
+@pytest.mark.parametrize('header,kwargs,message', [
+    ((), {}, 'invalid value field: value'),
+    (('id', 'variable', 'value'), {'valuefield': 'missing'},
+     'invalid value field: missing'),
+    (('id', 'variable', 'value'), {'key': 'missing'},
+     'invalid key field: missing'),
+    (('id', 'variable', 'value'), {'variablefield': 'missing'},
+     'invalid variable field: missing'),
+    (('id', 'variable', 'value'), {'variablefield': {'missing': ['x']}},
+     'invalid variable field: missing'),
+    (('id', 'variable', 'value'), {'key': ['id', 'value']},
+     'value field cannot be a key field'),
+    (('id', 'variable', 'value'), {'variablefield': ['variable', 'value']},
+     'value field cannot be a variable field'),
+])
+def test_recast_invalid_fields(header, kwargs, message):
+    with pytest.raises(ArgumentError) as exc:
+        list(recast([header], **kwargs))
+    assert str(exc.value) == 'argument error: ' + message
+
+
+def test_recast_validation_with_optimization():
+    code = """
+from petl import empty, recast
+from petl.errors import ArgumentError
+try:
+    list(recast(empty()))
+except ArgumentError:
+    pass
+else:
+    raise RuntimeError('recast accepted a missing value field')
+"""
+    subprocess.check_call([sys.executable, '-O', '-c', code])

--- a/petl/transform/reshape.py
+++ b/petl/transform/reshape.py
@@ -7,6 +7,7 @@ import operator
 from petl.compat import next, text_type
 
 
+from petl.errors import ArgumentError
 from petl.comparison import comparable_itemgetter
 from petl.util.base import Table, rowgetter, values, itervalues, \
     header, data, asindices
@@ -261,6 +262,12 @@ def recast(table, key=None, variablefield='variable', valuefield='value',
     time to reshape the data and recast variables as fields. How many rows are
     scanned in the first pass is determined by the `samplesize` argument.
 
+    When the result is iterated, invalid key, variable or value field names
+    raise :class:`petl.errors.ArgumentError`. The value field must exist in the
+    input header and must not also be selected as a key or variable field.
+    This also applies to an empty table with no fields; define the expected
+    header before recasting it.
+
     See also :func:`petl.transform.reshape.melt`.
 
     """
@@ -334,15 +341,19 @@ def iterrecast(source, key, variablefield, valuefield,
         variablefields = [f for f in flds
                           if f not in keyfields and f != valuefield]
 
-    # sanity checks
-    assert valuefield in flds, 'invalid value field: %s' % valuefield
-    assert valuefield not in keyfields, 'value field cannot be keyfields'
-    assert valuefield not in variablefields, \
-        'value field cannot be variable field'
+    # Validate user-supplied fields even when assertions are disabled.
+    if valuefield not in flds:
+        raise ArgumentError('invalid value field: %s' % valuefield)
+    if valuefield in keyfields:
+        raise ArgumentError('value field cannot be a key field')
+    if valuefield in variablefields:
+        raise ArgumentError('value field cannot be a variable field')
     for f in keyfields:
-        assert f in flds, 'invalid keyfields field: %s' % f
+        if f not in flds:
+            raise ArgumentError('invalid key field: %s' % f)
     for f in variablefields:
-        assert f in flds, 'invalid variable field: %s' % f
+        if f not in flds:
+            raise ArgumentError('invalid variable field: %s' % f)
 
     # we'll need these later
     valueindex = flds.index(valuefield)


### PR DESCRIPTION
`recast(empty())` currently raises an assertion failure, and invalid field checks disappear under `python -O`. Replace the five assertion-based checks with explicit `ArgumentError` exceptions at the shared iteration boundary. Valid recasts retain their behavior.

Fixes #297.

## Changes

- Validate missing value/key/variable fields and conflicting value-field roles independently of optimization.
- Cover the reported empty header, scalar/list/dictionary selections, and optimized interpreter execution.
- Document the exception contract and how to supply an empty table's header; add a changelog entry.

## Validation

Seven new invalid-field cases failed before the change. Utility and transformation tests now pass: **362 passed, 1 skipped**, including the optimized subprocess. Sphinx HTML with warnings as errors and `git diff --check` pass. Tested locally with Python 3.12; the complete tox interpreter matrix and external database tests were not run locally.

## Checklist

- [x] Unit tests included in the normal pytest suite
- [x] Behavior documented in the existing API docstring and docs/changes.rst
- [x] Atomic, reversible commit based on master; no incomplete changes
- [x] Tested locally with pytest
- [ ] CI and coverage results confirmed
- [x] Ready to review

AI-assisted implementation and validation.
